### PR TITLE
Add Automatic-Module-Name attribute to manifest files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,6 +327,7 @@ org.netbeans.html.boot.impl:org.netbeans.html.boot.fx:org.netbeans.html.context.
                     <instructions>
                         <Export-Package>${publicPackages},META-INF.services.*;-noimport:=true;-split-package:=first</Export-Package>
                         <Bundle-SymbolicName>${bundleSymbolicName}</Bundle-SymbolicName>
+                        <Automatic-Module-Name>${bundleSymbolicName}</Automatic-Module-Name>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This change will provide the user with a predictable automatic module 
name on a JDK9 module path, that is expected to be unique. This module 
name is independent of the name of the jar file, even if it is renamed 
by the user.