### PR TITLE
Make @JavaScriptResource repeatable

### DIFF
--- a/boot/src/main/java/net/java/html/js/JavaScriptResource.java
+++ b/boot/src/main/java/net/java/html/js/JavaScriptResource.java
@@ -19,6 +19,7 @@
 package net.java.html.js;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -38,9 +39,26 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.TYPE)
+@Repeatable(JavaScriptResource.Group.class)
 public @interface JavaScriptResource {
     /** The JavaScript file to load in before associated class can execute.
      * @return relative path with respect to the annotated class
      */
     public String value();
+
+    /** Represents a group of resources to load. When initializing element
+     * annotated by {@code Group} annotation, load all resources, one by one, in the
+     * order they appear in the {@link Group#value() array}.
+     *
+     * @since 1.6
+     */
+    @Retention(RetentionPolicy.CLASS)
+    @Target(ElementType.TYPE)
+    public static @interface Group {
+        /** Multiple instances of {@link JavaScriptResource} to load.
+         *
+         * @return array of resources to load
+         */
+        JavaScriptResource[] value();
+    }
 }

--- a/boot/src/main/java/net/java/html/js/JavaScriptResource.java
+++ b/boot/src/main/java/net/java/html/js/JavaScriptResource.java
@@ -51,9 +51,11 @@ public @interface JavaScriptResource {
      * order they appear in the {@link Group#value() array}.
      *
      * @since 1.6
+     * @deprecated Don't use directly. Repeat the {@link JavaScriptResource} annotation.
      */
     @Retention(RetentionPolicy.CLASS)
     @Target(ElementType.TYPE)
+    @Deprecated
     public static @interface Group {
         /** Multiple instances of {@link JavaScriptResource} to load.
          *

--- a/json-tck/pom.xml
+++ b/json-tck/pom.xml
@@ -55,6 +55,15 @@
                   <includeDependencySources>true</includeDependencySources>
               </configuration>
           </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>2.3.2</version>
+            <configuration>
+               <source>1.8</source>
+               <target>1.8</target>
+            </configuration>
+         </plugin>
       </plugins>
   </build>
   <dependencies>

--- a/json-tck/src/main/java/net/java/html/js/tests/JavaScriptBodyTest.java
+++ b/json-tck/src/main/java/net/java/html/js/tests/JavaScriptBodyTest.java
@@ -434,6 +434,11 @@ public class JavaScriptBodyTest {
     }
 
     @KOTest
+    public void orderOfJavaScriptResources() throws Exception {
+        assertEquals("Hello World!", ResourceOrder.helloWorld());
+    }
+
+    @KOTest
     public void globalValueInCallbackAvailable() throws Exception {
         final String[] value = { null, null };
         Bodies.callback(new Runnable() {

--- a/json-tck/src/main/java/net/java/html/js/tests/ResourceOrder.java
+++ b/json-tck/src/main/java/net/java/html/js/tests/ResourceOrder.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package net.java.html.js.tests;
+
+import net.java.html.js.JavaScriptBody;
+import net.java.html.js.JavaScriptResource;
+
+@JavaScriptResource("initArray.js")
+@JavaScriptResource("addHello.js")
+@JavaScriptResource("addWorld.js")
+public class ResourceOrder {
+    @JavaScriptBody(args = {  }, body = "return testArray.join(' ');")
+    public static native String helloWorld();
+}

--- a/json-tck/src/main/resources/net/java/html/js/tests/addHello.js
+++ b/json-tck/src/main/resources/net/java/html/js/tests/addHello.js
@@ -1,0 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+testArray.push("Hello");
+

--- a/json-tck/src/main/resources/net/java/html/js/tests/addWorld.js
+++ b/json-tck/src/main/resources/net/java/html/js/tests/addWorld.js
@@ -1,0 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+testArray.push("World!");
+

--- a/json-tck/src/main/resources/net/java/html/js/tests/initArray.js
+++ b/json-tck/src/main/resources/net/java/html/js/tests/initArray.js
@@ -1,0 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+testArray = [];
+

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@ org.netbeans.html.boot.impl:org.netbeans.html.boot.fx:org.netbeans.html.context.
                     <artifactId>codesnippet-doclet</artifactId>
                     <version>0.22</version>
                 </docletArtifact>
-                <additionalparam>-snippetpath "${basedir}" ${javadoc.allowjs}</additionalparam>
+                <additionalparam>-snippetpath "${basedir}" ${javadoc.allowjs} -hiddingannotation java.lang.Deprecated</additionalparam>
               </configuration>
             </plugin>
             <plugin>

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -126,6 +126,9 @@
             {@link net.java.html.json.ComputedProperty Computed properties} can
             depend on other computed properties -
             <a target="_blank" href="https://github.com/apache/incubator-netbeans-html4j/pull/3">PR #3</a>.
+            {@link net.java.html.js.JavaScriptResource} annotation has been
+            made repeatable -
+            <a target="_blank" href="https://github.com/apache/incubator-netbeans-html4j/pull/4">PR #4</a>.
         </p>
 
         <h3>New in version 1.5.1</h3>


### PR DESCRIPTION
Some people, for example Toni Epple, complained that it is hard to load multiple JavaScript files at once with `@JavaScriptResource` annotation. This can easily be fixed by making it `@Repeatable`. The change to API is minimal, the implementation is simple.

The biggest challenge will be for guys with non-JVM implementations of the `@JavaScriptResource` - e.g. [Bck2Brwsr](http://bck2brwsr.apidesign.org) and [TeaVM](http://teavm.org). But it shall be possible to handle the change, right @konsoletyper?