### PR TITLE
Missing Audio object caused exception

### DIFF
--- a/sound/pom.xml
+++ b/sound/pom.xml
@@ -46,13 +46,37 @@
               <groupId>org.netbeans.html</groupId>
               <artifactId>html4j-maven-plugin</artifactId>
           </plugin>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <version>2.19.1</version>
+              <configuration>
+                  <junitArtifactName>com.dukescript.api:junit-osgi</junitArtifactName>
+                  <systemPropertyVariables>
+                      <fxpresenter.headless>true</fxpresenter.headless>
+                  </systemPropertyVariables>
+              </configuration>
+          </plugin>
         </plugins>
     </build>
     <dependencies>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>com.dukescript.api</groupId>
+            <artifactId>junit-browser-runner</artifactId>
+            <version>1.0</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.html</groupId>
+            <artifactId>net.java.html.boot.script</artifactId>
+            <version>${project.version}</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.html</groupId>
+            <artifactId>net.java.html.boot.fx</artifactId>
+            <version>${project.version}</version>
+            <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.netbeans.html</groupId>

--- a/sound/src/main/java/org/netbeans/html/sound/impl/BrowserAudioEnv.java
+++ b/sound/src/main/java/org/netbeans/html/sound/impl/BrowserAudioEnv.java
@@ -34,7 +34,7 @@ public final class BrowserAudioEnv implements AudioEnvironment<Object> {
     
     @Override
     @JavaScriptBody(args = { "src" }, body = ""
-        + "if (!Audio) return null;"
+        + "if (typeof Audio !== 'object') return null;"
         + "return new Audio(src);")
     public Object create(String src) {
         // null if not running in browser

--- a/sound/src/test/java/net/java/html/sound/AudioClipTest.java
+++ b/sound/src/test/java/net/java/html/sound/AudioClipTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package net.java.html.sound;
+
+import net.java.html.junit.BrowserRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(BrowserRunner.class)
+public class AudioClipTest {
+
+    public AudioClipTest() {
+    }
+
+    @Test
+    public void testPlayNonExistingClip() {
+        AudioClip.create("non-existing.mp3").play();
+    }
+}


### PR DESCRIPTION
While playing with my [fair minesweeper](http://github.com/jtulach/minesweeper) game I realized that  missing `Audio` object causes script errors. Changing the check to `typeof Audio === 'object'`. Thanks for your review.