### PR TITLE
updating the overview to point to latest documentation location

### DIFF
--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -99,7 +99,7 @@ $ mvn -f client/pom.xml process-classes exec:exec
         <h3>More Information</h3>
         <p>We tried to make our API Docs as useful as possible, so they contain 
             lots of valuable information. So this should be your first stop when looking for information:
-            Current <a target="_blank" href="http://bits.netbeans.org/html+java/dev/">development</a> version
+            Current <a target="_blank" href="https://dukescript.com/javadoc/html+java/dev/">development</a> version
             
         </p>
         <p>The <a href="http://dukescript.com" target="_blank">DukeScript project</a> contains a lot of information for Java/HTML developers.
@@ -489,7 +489,8 @@ $ mvn -f client/pom.xml process-classes exec:exec
         The javadoc for latest and previous versions is also available
         online:
         <ul>
-            <li>Current <a target="_blank" href="http://bits.netbeans.org/html+java/dev/">development</a> version
+            <li>Current <a target="_blank" href="https://dukescript.com/javadoc/html+java/dev/">development</a> version
+            <li>Version <a target="_blank" href="https://dukescript.com/javadoc/html+java/1.5.1/">1.5.1</a>
             <li>Version <a target="_blank" href="http://bits.netbeans.org/html+java/1.5">1.5</a>
             <li>Version <a target="_blank" href="http://bits.netbeans.org/html+java/1.4">1.4</a>
             <li>Version <a target="_blank" href="http://bits.netbeans.org/html+java/1.3">1.3</a>


### PR DESCRIPTION
and adding additional param required for script in javadoc comments (required since 8_u121)