### PR TITLE
Allow one to explicitly specify script engine

### DIFF
--- a/boot-script/pom.xml
+++ b/boot-script/pom.xml
@@ -31,7 +31,7 @@
     <version>2.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <properties>
-        <netbeans.compile.on.save>NONE</netbeans.compile.on.save>
+        <netbeans.compile.on.save>none</netbeans.compile.on.save>
         <publicPackages>net.java.html.boot.script</publicPackages>
     </properties>
     <build>
@@ -108,7 +108,6 @@
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <scope>test</scope>
-            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.netbeans.html</groupId>

--- a/boot-script/src/main/java/net/java/html/boot/script/Sanitizer.java
+++ b/boot-script/src/main/java/net/java/html/boot/script/Sanitizer.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package net.java.html.boot.script;
+
+import javax.script.Invocable;
+import javax.script.ScriptEngine;
+import javax.script.ScriptException;
+
+final class Sanitizer {
+    private Sanitizer() {
+    }
+
+    private static final String[] ALLOWED_GLOBALS = (""
+    + "Object,Function,Array,String,Date,Number,BigInt,"
+    + "Boolean,RegExp,Math,JSON,NaN,Infinity,undefined,"
+    + "isNaN,isFinite,parseFloat,parseInt,encodeURI,"
+    + "encodeURIComponent,decodeURI,decodeURIComponent,eval,"
+    + "escape,unescape,"
+    + "Error,EvalError,RangeError,ReferenceError,SyntaxError,"
+    + "TypeError,URIError,ArrayBuffer,Int8Array,Uint8Array,"
+    + "Uint8ClampedArray,Int16Array,Uint16Array,Int32Array,"
+    + "Uint32Array,Float32Array,Float64Array,BigInt64Array,"
+    + "BigUint64Array,DataView,Map,Set,WeakMap,"
+    + "WeakSet,Symbol,Reflect,Proxy,Promise,SharedArrayBuffer,"
+    + "Atomics,console,performance,"
+    + "arguments,load").split(",");
+
+
+    static void clean(ScriptEngine engine) throws ScriptException {
+        try {
+            Object cleaner = engine.eval(""
+                + "(function(allowed) {\n"
+                + "   var names = Object.getOwnPropertyNames(this);\n"
+                + "   MAIN: for (var i = 0; i < names.length; i++) {\n"
+                + "     for (var j = 0; j < allowed.length; j++) {\n"
+                + "       if (names[i] === allowed[j]) {\n"
+                + "         continue MAIN;\n"
+                + "       }\n"
+                + "     }\n"
+                + "     delete this[names[i]];\n"
+                + "   }\n"
+                + "})"
+            );
+            ((Invocable) engine).invokeMethod(cleaner, "call", null, ALLOWED_GLOBALS);
+        } catch (NoSuchMethodException ex) {
+            throw new ScriptException(ex);
+        }
+    }
+
+    static void defineAlert(ScriptEngine engine) throws ScriptException {
+        try {
+            Object defineAlert = engine.eval(""
+                + "(function(out) {\n"
+                + "  this.alert = function(msg) {\n"
+                + "    out.println(msg);\n"
+                + " };"
+                + "});"
+            );
+            ((Invocable) engine).invokeMethod(defineAlert, "call", null, System.out);
+        } catch (NoSuchMethodException ex) {
+            throw new ScriptException(ex);
+        }
+    }
+}

--- a/boot-script/src/main/java/net/java/html/boot/script/ScriptPresenter.java
+++ b/boot-script/src/main/java/net/java/html/boot/script/ScriptPresenter.java
@@ -20,7 +20,6 @@ package net.java.html.boot.script;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.ObjectOutput;
 import java.io.Reader;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Array;
@@ -72,19 +71,19 @@ Presenter, Fn.FromJavaScript, Fn.ToJavaScript, Executor {
     private final Set<Class<?>> jsReady;
     private final CallbackImpl callback;
 
-    ScriptPresenter(Executor exc) {
-        this(new ScriptEngineManager().getEngineByName("javascript"), exc);
-    }
-
-    ScriptPresenter(ScriptEngine eng, Executor exc) {
+    ScriptPresenter(ScriptEngine eng, Executor exc, boolean sanitize) {
+        if (eng == null) {
+            eng = new ScriptEngineManager().getEngineByName("javascript");
+        }
         this.eng = eng;
         this.exc = exc;
         try {
-            eng.eval("function alert(msg) { Packages.java.lang.System.out.println(msg); };");
-            eng.eval("function confirm(msg) { Packages.java.lang.System.out.println(msg); return true; };");
-            eng.eval("function prompt(msg, txt) { Packages.java.lang.System.out.println(msg + ':' + txt); return txt; };");
             Object undef = new UndefinedCallback().undefined(eng);
             this.undefined = undef;
+            if (sanitize) {
+                Sanitizer.clean(eng);
+            }
+            Sanitizer.defineAlert(eng);
         } catch (ScriptException ex) {
             throw new IllegalStateException(ex);
         }

--- a/boot-script/src/test/java/net/java/html/boot/script/KnockoutEnvJSTest.java
+++ b/boot-script/src/test/java/net/java/html/boot/script/KnockoutEnvJSTest.java
@@ -84,7 +84,11 @@ public final class KnockoutEnvJSTest extends KnockoutTCK {
 
         baseUri = DynamicHTTP.initServer();
 
-        final Fn.Presenter p = new ScriptPresenter(eng, KOCase.JS);
+        final Fn.Presenter p = Scripts.newPresenter()
+            .engine(eng)
+            .sanitize(false)
+            .executor(KOCase.JS)
+            .build();
         try {
             Class.forName("java.lang.Module");
         } catch (ClassNotFoundException oldJDK) {

--- a/boot-script/src/test/java/net/java/html/boot/script/ScriptsTest.java
+++ b/boot-script/src/test/java/net/java/html/boot/script/ScriptsTest.java
@@ -1,0 +1,139 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package net.java.html.boot.script;
+
+import java.io.Closeable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import net.java.html.boot.BrowserBuilder;
+import net.java.html.js.JavaScriptBody;
+import org.netbeans.html.boot.spi.Fn;
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+public class ScriptsTest {
+
+    public ScriptsTest() {
+    }
+
+    @Test
+    public void testNewPresenterNoExecutor() throws Exception {
+        // BEGIN: ScriptsTest#testNewPresenterNoExecutor
+        Fn.Presenter presenter = Scripts.newPresenter().build();
+        // END: ScriptsTest#testNewPresenterNoExecutor
+        assertNotNull(presenter);
+        Fn fn = presenter.defineFn("return a * b", "a", "b");
+        Object fourtyTwo = fn.invoke(null, 6, 7);
+        assertTrue(fourtyTwo instanceof Number);
+        assertEquals(((Number)fourtyTwo).intValue(), 42);
+    }
+
+    @Test
+    public void testActivatePresenterDirectly() throws Exception {
+        int fortyTwo = activatePresenterDirectly();
+        assertEquals(fortyTwo, 42);
+    }
+
+    // BEGIN: ScriptsTest#activatePresenterDirectly
+    @JavaScriptBody(args = { "a", "b" }, body = "return a * b;")
+    private static native int mul(int a, int b);
+
+    private static int activatePresenterDirectly() throws Exception {
+        Fn.Presenter p = Scripts.newPresenter().build();
+        try (Closeable c = Fn.activate(p)) {
+            int fortyTwo = mul(2, mul(7, 3));
+            assert fortyTwo == 42;
+            return fortyTwo;
+        }
+    }
+    // END: ScriptsTest#activatePresenterDirectly
+
+    @Test
+    public void initViaBrowserBuilder() throws Exception {
+        String[] executed = { null };
+        // BEGIN: ScriptsTest#initViaBrowserBuilder
+        Runnable run = () -> {
+            executed[0] = "OK";
+        };
+        Fn.Presenter p = Scripts.newPresenter().build();
+        BrowserBuilder.newBrowser(p)
+            .loadFinished(run)
+            .loadPage("empty.html")
+            .showAndWait();
+        // END: ScriptsTest#initViaBrowserBuilder
+        assertEquals(executed[0], "OK", "Executed without issues");
+    }
+
+    @Test
+    public void isSanitizationOnByDefault() throws Exception {
+        assertSanitized(Scripts.newPresenter());
+    }
+
+    @Test
+    public void isSanitizationOnExplicitly() throws Exception {
+        assertSanitized(Scripts.newPresenter().sanitize(true));
+    }
+
+    @Test
+    public void noSanitization() throws Exception {
+        assertNotSanitized(Scripts.newPresenter().sanitize(false));
+    }
+
+    private void assertSanitized(Scripts newPresenter) throws Exception {
+        Fn.Presenter p = newPresenter.build();
+        awaitPresenter(p);
+        try (Closeable c = Fn.activate(p)) {
+            Object Java = p.defineFn("return typeof Java;").invoke(null);
+            Object engine = p.defineFn("return typeof engine;").invoke(null);
+            Object Packages = p.defineFn("return typeof Packages;").invoke(null);
+            Object alert = p.defineFn("return typeof alert;").invoke(null);
+            assertEquals(Java, "undefined", "No Java symbol");
+            assertEquals(engine, "undefined", "No engine symbol");
+            assertEquals(Packages, "undefined", "No Packages symbol");
+            assertEquals(alert, "function", "alert is defined symbol");
+        }
+    }
+
+    private void assertNotSanitized(Scripts builder) throws Exception {
+        Fn.Presenter p = builder.build();
+        try (Closeable c = Fn.activate(p)) {
+            Object Java = p.defineFn("return typeof Java;").invoke(null);
+            Object engine = p.defineFn("return typeof engine;").invoke(null);
+            Object Packages = p.defineFn("return typeof Packages;").invoke(null);
+            Object alert = p.defineFn("return typeof alert;").invoke(null);
+            assertEquals(Java, "object", "Java symbol found");
+            assertEquals(engine, "object", "Engine symbol found");
+            assertEquals(Packages, "object", "Packages symbol found");
+            assertEquals(alert, "function", "alert is defined symbol");
+        }
+    }
+
+    private static void awaitPresenter(Fn.Presenter p) {
+        Executor e = (Executor) p;
+        CountDownLatch cdl = new CountDownLatch(1);
+        e.execute(cdl::countDown);
+        try {
+            cdl.await();
+        } catch (InterruptedException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,13 @@ org.netbeans.html.boot.impl:org.netbeans.html.boot.fx:org.netbeans.html.context.
                     <artifactId>codesnippet-doclet</artifactId>
                     <version>0.23</version>
                 </docletArtifact>
-                <additionalparam>-snippetpath json/src/test -snippetpath boot-fx/src/test ${javadoc.allowjs} -hiddingannotation java.lang.Deprecated</additionalparam>
+                <additionalparam>
+                    -snippetpath boot-fx/src/test 
+                    -snippetpath boot-script/src/test
+                    -snippetpath json/src/test
+                    ${javadoc.allowjs}
+                    -hiddingannotation java.lang.Deprecated
+                </additionalparam>
               </configuration>
             </plugin>
             <plugin>
@@ -268,6 +274,8 @@ org.netbeans.html.boot.impl:org.netbeans.html.boot.fx:org.netbeans.html.context.
                 <configuration>
                     <source>1.6</source>
                     <target>1.6</target>
+                    <testSource>1.8</testSource>
+                    <testTarget>1.8</testTarget>
                 </configuration>
               </plugin>
               <plugin>

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -167,6 +167,9 @@ $ mvn -f client/pom.xml process-classes exec:exec
         <p>
             One model instance can be used in two views
             (<a target="_blank" href="https://github.com/apache/incubator-netbeans-html4j/pull/14">PR #14</a>).
+            Safe and {@link net.java.html.boot.script.Scripts sanitized builder} to
+            create {@link javax.script.ScriptEngine}-based execution environment
+            (<a target="_blank" href="https://github.com/apache/incubator-netbeans-html4j/pull/15">PR #15</a>).
         </p>
 
         <h3>New in version 1.6</h3>


### PR DESCRIPTION
I'd like to make the `Scripts` builder the most secure way to use JavaScript from Java. This is the first step.

CCing @eppleton, @matthiasblaesing, @jlahoda, @eirikbakke 