### PR TITLE
Using NetBeans Parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,9 @@
   <packaging>pom</packaging>
   <name>HTML APIs via Java</name>
   <parent>
-      <groupId>org.apache</groupId>
-      <artifactId>apache</artifactId>
-      <version>10</version>
+      <groupId>org.apache.netbeans</groupId>
+      <artifactId>netbeans-parent</artifactId>
+      <version>1</version>
   </parent>
   <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
The vote about Apache NetBeans parent POM 1 is going on. This is an attempt to verify it works for HTML/Java API. So far the upload looks OK.

Right now the POM has to be installed manually. Merge when the vote is approved. 