### PR TITLE
Wrap FileWriter with BufferedWriter when used in a loop for a better performance

### DIFF
--- a/html4j-maven-plugin/src/main/java/org/netbeans/html/mojo/ProcessJsAnnotations.java
+++ b/html4j-maven-plugin/src/main/java/org/netbeans/html/mojo/ProcessJsAnnotations.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.html.mojo;
 
+import java.io.BufferedWriter;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -159,7 +160,7 @@ abstract class ProcessJsAnnotations {
             if (arr.isEmpty()) {
                 f.delete();
             } else {
-                try (FileWriter w = f.writer()) {
+                try (BufferedWriter w = new BufferedWriter(f.writer())) {
                     for (String l : arr) {
                         w.write(l);
                         w.write("\n");


### PR DESCRIPTION
When a FileWriter is intensively used in a loop, the wrapper class BufferedWriter is highly recommended to gain a good performance.