### PR TITLE
Make sure unused presenters can GC

### DIFF
--- a/boot-fx/pom.xml
+++ b/boot-fx/pom.xml
@@ -83,6 +83,13 @@
       <artifactId>javafx-web</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.netbeans.api</groupId>
+      <artifactId>org-netbeans-modules-nbjunit</artifactId>
+      <version>${netbeans.version}</version>
+      <scope>test</scope>
+      <type>jar</type>
+    </dependency>
   </dependencies>
     <description>A presentation provider to show JavaFX WebView 
 when a Java/HTML based application is about to boot.</description>

--- a/boot-fx/src/main/java/net/java/html/boot/fx/FXBrowsers.java
+++ b/boot-fx/src/main/java/net/java/html/boot/fx/FXBrowsers.java
@@ -25,6 +25,7 @@ import javafx.scene.web.WebView;
 import net.java.html.BrwsrCtx;
 import net.java.html.boot.BrowserBuilder;
 import net.java.html.js.JavaScriptBody;
+import org.netbeans.html.boot.spi.Fn;
 import org.netbeans.html.context.spi.Contexts;
 import org.netbeans.html.context.spi.Contexts.Id;
 
@@ -200,6 +201,9 @@ public final class FXBrowsers {
      */
     public static void runInBrowser(WebView webView, Runnable code) {
         Object ud = webView.getUserData();
+        if (ud instanceof Fn.Ref<?>) {
+            ud = ((Fn.Ref<?>)ud).presenter();
+        }
         if (!(ud instanceof InitializeWebView)) {
             throw new IllegalArgumentException();
         }

--- a/boot-fx/src/main/java/org/netbeans/html/boot/fx/AbstractFXPresenter.java
+++ b/boot-fx/src/main/java/org/netbeans/html/boot/fx/AbstractFXPresenter.java
@@ -50,7 +50,7 @@ import org.netbeans.html.boot.spi.Fn;
  * @author Jaroslav Tulach
  */
 public abstract class AbstractFXPresenter implements Fn.Presenter,
-Fn.KeepAlive, Fn.ToJavaScript, Fn.FromJavaScript, Executor, Cloneable, Fn.Identity {
+Fn.KeepAlive, Fn.ToJavaScript, Fn.FromJavaScript, Executor, Cloneable, Fn.Ref<AbstractFXPresenter> {
     static final Logger LOG = Logger.getLogger(FXPresenter.class.getName());
     protected static int cnt;
     protected Runnable onLoad;
@@ -605,7 +605,7 @@ Fn.KeepAlive, Fn.ToJavaScript, Fn.FromJavaScript, Executor, Cloneable, Fn.Identi
     }
 
     @Override
-    public synchronized Fn.Identity id() {
+    public synchronized Fn.Ref<AbstractFXPresenter> reference() {
         if (id == null) {
             id = new Id(this);
         }
@@ -613,22 +613,22 @@ Fn.KeepAlive, Fn.ToJavaScript, Fn.FromJavaScript, Executor, Cloneable, Fn.Identi
     }
 
     @Override
-    public Fn.Presenter presenter() {
+    public AbstractFXPresenter presenter() {
         return this;
     }
 
-    private static final class Id extends WeakReference<AbstractFXPresenter> implements Fn.Identity {
+    private static final class Id extends WeakReference<AbstractFXPresenter> implements Fn.Ref<AbstractFXPresenter> {
         Id(AbstractFXPresenter referent) {
             super(referent);
         }
 
         @Override
-        public Fn.Identity id() {
+        public Fn.Ref<AbstractFXPresenter> reference() {
             return this;
         }
 
         @Override
-        public Fn.Presenter presenter() {
+        public AbstractFXPresenter presenter() {
             return get();
         }
     }

--- a/boot-fx/src/main/java/org/netbeans/html/boot/fx/AbstractFXPresenter.java
+++ b/boot-fx/src/main/java/org/netbeans/html/boot/fx/AbstractFXPresenter.java
@@ -50,7 +50,7 @@ import org.netbeans.html.boot.spi.Fn;
  * @author Jaroslav Tulach
  */
 public abstract class AbstractFXPresenter implements Fn.Presenter,
-Fn.KeepAlive, Fn.ToJavaScript, Fn.FromJavaScript, Executor, Cloneable {
+Fn.KeepAlive, Fn.ToJavaScript, Fn.FromJavaScript, Executor, Cloneable, Fn.Identity {
     static final Logger LOG = Logger.getLogger(FXPresenter.class.getName());
     protected static int cnt;
     protected Runnable onLoad;
@@ -62,6 +62,7 @@ Fn.KeepAlive, Fn.ToJavaScript, Fn.FromJavaScript, Executor, Cloneable {
     private JSObject newPOJOImpl;
     private Object undefined;
     private JavaValues values;
+    private Id id;
 
     @Override
     protected AbstractFXPresenter clone() {
@@ -72,6 +73,7 @@ Fn.KeepAlive, Fn.ToJavaScript, Fn.FromJavaScript, Executor, Cloneable {
             p.undefined = null;
             p.newPOJOImpl = null;
             p.values = null;
+            p.id = null;
             return p;
         } catch (CloneNotSupportedException ex) {
             throw new IllegalStateException(ex);
@@ -602,4 +604,32 @@ Fn.KeepAlive, Fn.ToJavaScript, Fn.FromJavaScript, Executor, Cloneable {
         return pojo[0];
     }
 
+    @Override
+    public synchronized Fn.Identity id() {
+        if (id == null) {
+            id = new Id(this);
+        }
+        return id;
+    }
+
+    @Override
+    public Fn.Presenter presenter() {
+        return this;
+    }
+
+    private static final class Id extends WeakReference<AbstractFXPresenter> implements Fn.Identity {
+        Id(AbstractFXPresenter referent) {
+            super(referent);
+        }
+
+        @Override
+        public Fn.Identity id() {
+            return this;
+        }
+
+        @Override
+        public Fn.Presenter presenter() {
+            return get();
+        }
+    }
 }

--- a/boot-fx/src/main/java/org/netbeans/html/boot/fx/InitializeWebView.java
+++ b/boot-fx/src/main/java/org/netbeans/html/boot/fx/InitializeWebView.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.html.boot.fx;
 
+import java.lang.ref.WeakReference;
 import java.net.URL;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
@@ -35,7 +36,7 @@ public final class InitializeWebView extends AbstractFXPresenter implements Runn
     public InitializeWebView(WebView webView, Runnable onLoad) {
         this.webView = webView;
         this.myLoad = onLoad;
-        webView.setUserData(this);
+        webView.setUserData(reference());
     }
 
     @Override
@@ -54,37 +55,54 @@ public final class InitializeWebView extends AbstractFXPresenter implements Runn
     @Override
     WebView findView(final URL resource) {
         final Worker<Void> w = webView.getEngine().getLoadWorker();
-        w.stateProperty().addListener(new ChangeListener<Worker.State>() {
-            private String previous;
-
-            @Override
-            public void changed(ObservableValue<? extends Worker.State> ov, Worker.State t, Worker.State newState) {
-                if (newState.equals(Worker.State.SUCCEEDED)) {
-                    if (checkValid()) {
-                        onPageLoad();
-                    }
-                }
-                if (newState.equals(Worker.State.FAILED)) {
-                    checkValid();
-                    throw new IllegalStateException("Failed to load " + resource);
-                }
-            }
-
-            private boolean checkValid() {
-                final String crnt = webView.getEngine().getLocation();
-                if (previous != null && !previous.equals(crnt)) {
-                    w.stateProperty().removeListener(this);
-                    return false;
-                }
-                previous = crnt;
-                return true;
-            }
-        });
+        w.stateProperty().addListener(new FindViewListener(this, resource, w));
         return webView;
     }
 
     public final void runInContext(Runnable r) {
         ctx.execute(r);
+    }
+
+    private static class FindViewListener extends WeakReference<InitializeWebView>
+    implements ChangeListener<Worker.State> {
+
+        private final URL resource;
+        private final Worker<Void> w;
+
+        public FindViewListener(InitializeWebView view, URL resource, Worker<Void> w) {
+            super(view);
+            this.resource = resource;
+            this.w = w;
+        }
+        private String previous;
+
+        @Override
+        public void changed(ObservableValue<? extends Worker.State> ov, Worker.State t, Worker.State newState) {
+            InitializeWebView view = get();
+            if (view == null) {
+                w.stateProperty().removeListener(this);
+                return;
+            }
+            if (newState.equals(Worker.State.SUCCEEDED)) {
+                if (checkValid(view)) {
+                    view.onPageLoad();
+                }
+            }
+            if (newState.equals(Worker.State.FAILED)) {
+                checkValid(view);
+                throw new IllegalStateException("Failed to load " + resource);
+            }
+        }
+
+        private boolean checkValid(InitializeWebView view) {
+            final String crnt = view.webView.getEngine().getLocation();
+            if (previous != null && !previous.equals(crnt)) {
+                w.stateProperty().removeListener(this);
+                return false;
+            }
+            previous = crnt;
+            return true;
+        }
     }
 
 }

--- a/boot-fx/src/test/java/org/netbeans/html/boot/fx/AbstractFXPresenterTest.java
+++ b/boot-fx/src/test/java/org/netbeans/html/boot/fx/AbstractFXPresenterTest.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.html.boot.fx;
+
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+import java.net.URL;
+import javafx.scene.web.WebView;
+import org.netbeans.html.boot.spi.Fn;
+import org.netbeans.junit.NbTestCase;
+import org.testng.Assert;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import org.testng.annotations.Test;
+
+public class AbstractFXPresenterTest {
+    @Test
+    public void id() {
+        AbstractFXPresenter p1 = new AbstractFXPresenter() {
+            @Override
+            void waitFinished() {
+            }
+
+            @Override
+            WebView findView(URL resource) {
+                return null;
+            }
+        };
+        AbstractFXPresenter p2 = new AbstractFXPresenter() {
+            @Override
+            void waitFinished() {
+            }
+
+            @Override
+            WebView findView(URL resource) {
+                return null;
+            }
+        };
+
+        Fn.Identity id1 = Fn.id(p1);
+        Fn.Identity id12 = Fn.id(p1);
+
+        assertSame(id1, id12);
+        assertEquals(id1, id12);
+
+        Fn.Identity id2 = Fn.id(p2);
+        Fn.Identity id22 = Fn.id(p2);
+
+        assertSame(id2, id22);
+        assertEquals(id2, id22);
+
+        Assert.assertNotEquals(id1, id2);
+
+        Reference<AbstractFXPresenter> ref1 = new WeakReference<>(p1);
+        p1 = null;
+        NbTestCase.assertGC("Presenter can disappear", ref1);
+
+        AbstractFXPresenter p2Clone = p2.clone();
+        Assert.assertNotEquals(p2.id(), p2Clone.id());
+    }
+}

--- a/boot-fx/src/test/java/org/netbeans/html/boot/fx/AbstractFXPresenterTest.java
+++ b/boot-fx/src/test/java/org/netbeans/html/boot/fx/AbstractFXPresenterTest.java
@@ -53,14 +53,16 @@ public class AbstractFXPresenterTest {
             }
         };
 
-        Fn.Identity id1 = Fn.id(p1);
-        Fn.Identity id12 = Fn.id(p1);
+        Fn.Ref<?> id1 = Fn.ref(p1);
+        Fn.Ref<?> id12 = Fn.ref(p1);
 
         assertSame(id1, id12);
         assertEquals(id1, id12);
+        assertSame(p1, id1.presenter());
 
-        Fn.Identity id2 = Fn.id(p2);
-        Fn.Identity id22 = Fn.id(p2);
+        Fn.Ref<?> id2 = Fn.ref(p2);
+        Fn.Ref<?> id22 = Fn.ref(p2);
+        assertSame(p2, id2.presenter());
 
         assertSame(id2, id22);
         assertEquals(id2, id22);
@@ -72,6 +74,6 @@ public class AbstractFXPresenterTest {
         NbTestCase.assertGC("Presenter can disappear", ref1);
 
         AbstractFXPresenter p2Clone = p2.clone();
-        Assert.assertNotEquals(p2.id(), p2Clone.id());
+        Assert.assertNotEquals(p2.reference(), p2Clone.reference());
     }
 }

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -77,6 +77,13 @@
       <version>${project.version}</version>
       <type>jar</type>
     </dependency>
+    <dependency>
+      <groupId>org.netbeans.api</groupId>
+      <artifactId>org-netbeans-modules-nbjunit</artifactId>
+      <version>${netbeans.version}</version>
+      <scope>test</scope>
+      <type>jar</type>
+    </dependency>
   </dependencies>
     <description>Builder to launch your Java/HTML based application.</description>
 </project>

--- a/boot/src/main/java/org/netbeans/html/boot/impl/FnUtils.java
+++ b/boot/src/main/java/org/netbeans/html/boot/impl/FnUtils.java
@@ -651,6 +651,9 @@ public final class FnUtils {
             if (name.equals(Fn.Presenter.class.getName())) {
                 return Fn.Presenter.class;
             }
+            if (name.equals(Fn.Identity.class.getName())) {
+                return Fn.Identity.class;
+            }
             if (name.equals(Fn.ToJavaScript.class.getName())) {
                 return Fn.ToJavaScript.class;
             }

--- a/boot/src/main/java/org/netbeans/html/boot/impl/FnUtils.java
+++ b/boot/src/main/java/org/netbeans/html/boot/impl/FnUtils.java
@@ -651,8 +651,8 @@ public final class FnUtils {
             if (name.equals(Fn.Presenter.class.getName())) {
                 return Fn.Presenter.class;
             }
-            if (name.equals(Fn.Identity.class.getName())) {
-                return Fn.Identity.class;
+            if (name.equals(Fn.Ref.class.getName())) {
+                return Fn.Ref.class;
             }
             if (name.equals(Fn.ToJavaScript.class.getName())) {
                 return Fn.ToJavaScript.class;

--- a/boot/src/main/java/org/netbeans/html/boot/impl/JavaScriptProcesor.java
+++ b/boot/src/main/java/org/netbeans/html/boot/impl/JavaScriptProcesor.java
@@ -400,19 +400,30 @@ public final class JavaScriptProcesor extends AbstractProcessor {
             source.append("package ").append(pkgName).append(";\n");
             source.append("public final class $JsCallbacks$ {\n");
             source.append("  static final $JsCallbacks$ VM = new $JsCallbacks$(null);\n");
-            source.append("  private final java.lang.ref.Reference<org.netbeans.html.boot.spi.Fn.Presenter> ref;\n");
+            source.append("  private final org.netbeans.html.boot.spi.Fn.Identity id;\n");
             source.append("  private $JsCallbacks$ next;\n");
             source.append("  private $JsCallbacks$(org.netbeans.html.boot.spi.Fn.Presenter p) {\n");
-            source.append("    this.ref = new java.lang.ref.WeakReference<org.netbeans.html.boot.spi.Fn.Presenter>(p);\n");
+            source.append("    this.id = org.netbeans.html.boot.spi.Fn.id(p);\n");
             source.append("  }\n");
             source.append("  synchronized final $JsCallbacks$ current() {\n");
             source.append("    org.netbeans.html.boot.spi.Fn.Presenter now = org.netbeans.html.boot.spi.Fn.activePresenter();\n");
             source.append("    $JsCallbacks$ thiz = this;\n");
+            source.append("    $JsCallbacks$ prev = null;\n");
             source.append("    for (;;) {\n");
-            source.append("      if (now == thiz.ref.get()) return thiz;\n");
+            source.append("      if (thiz.id != null) {\n");
+            source.append("        org.netbeans.html.boot.spi.Fn.Presenter thizPresenter = thiz.id.presenter();\n");
+            source.append("        if (thizPresenter == null) {\n");
+            source.append("          if (prev != null) {\n");
+            source.append("            prev.next = thiz.next;\n");
+            source.append("          }\n");
+            source.append("        } else {\n");
+            source.append("          if (thizPresenter == now) return thiz;\n");
+            source.append("        }\n");
+            source.append("      }\n");
             source.append("      if (thiz.next == null) {\n");
             source.append("        return thiz.next = new $JsCallbacks$(now);\n");
             source.append("      }\n");
+            source.append("      prev = thiz;\n");
             source.append("      thiz = thiz.next;\n");
             source.append("    }\n");
             source.append("  }\n");
@@ -486,7 +497,7 @@ public final class JavaScriptProcesor extends AbstractProcessor {
             sep = ", ";
         }
         source.append(") throws Throwable {\n");
-        source.append("    org.netbeans.html.boot.spi.Fn.Presenter p = ref.get(); \n");
+        source.append("    org.netbeans.html.boot.spi.Fn.Presenter p = id.presenter(); \n");
         source.append(convert);
         if (useTryResources()) {
             source.append("    try (java.io.Closeable a = org.netbeans.html.boot.spi.Fn.activate(p)) { \n");

--- a/boot/src/main/java/org/netbeans/html/boot/impl/JavaScriptProcesor.java
+++ b/boot/src/main/java/org/netbeans/html/boot/impl/JavaScriptProcesor.java
@@ -400,18 +400,18 @@ public final class JavaScriptProcesor extends AbstractProcessor {
             source.append("package ").append(pkgName).append(";\n");
             source.append("public final class $JsCallbacks$ {\n");
             source.append("  static final $JsCallbacks$ VM = new $JsCallbacks$(null);\n");
-            source.append("  private final org.netbeans.html.boot.spi.Fn.Identity id;\n");
+            source.append("  private final org.netbeans.html.boot.spi.Fn.Ref<?> ref;\n");
             source.append("  private $JsCallbacks$ next;\n");
             source.append("  private $JsCallbacks$(org.netbeans.html.boot.spi.Fn.Presenter p) {\n");
-            source.append("    this.id = org.netbeans.html.boot.spi.Fn.id(p);\n");
+            source.append("    this.ref = org.netbeans.html.boot.spi.Fn.ref(p);\n");
             source.append("  }\n");
             source.append("  synchronized final $JsCallbacks$ current() {\n");
             source.append("    org.netbeans.html.boot.spi.Fn.Presenter now = org.netbeans.html.boot.spi.Fn.activePresenter();\n");
             source.append("    $JsCallbacks$ thiz = this;\n");
             source.append("    $JsCallbacks$ prev = null;\n");
             source.append("    for (;;) {\n");
-            source.append("      if (thiz.id != null) {\n");
-            source.append("        org.netbeans.html.boot.spi.Fn.Presenter thizPresenter = thiz.id.presenter();\n");
+            source.append("      if (thiz.ref != null) {\n");
+            source.append("        org.netbeans.html.boot.spi.Fn.Presenter thizPresenter = thiz.ref.presenter();\n");
             source.append("        if (thizPresenter == null) {\n");
             source.append("          if (prev != null) {\n");
             source.append("            prev.next = thiz.next;\n");
@@ -497,7 +497,7 @@ public final class JavaScriptProcesor extends AbstractProcessor {
             sep = ", ";
         }
         source.append(") throws Throwable {\n");
-        source.append("    org.netbeans.html.boot.spi.Fn.Presenter p = id.presenter(); \n");
+        source.append("    org.netbeans.html.boot.spi.Fn.Presenter p = ref.presenter(); \n");
         source.append(convert);
         if (useTryResources()) {
             source.append("    try (java.io.Closeable a = org.netbeans.html.boot.spi.Fn.activate(p)) { \n");

--- a/boot/src/main/java/org/netbeans/html/boot/impl/JavaScriptProcesor.java
+++ b/boot/src/main/java/org/netbeans/html/boot/impl/JavaScriptProcesor.java
@@ -400,16 +400,16 @@ public final class JavaScriptProcesor extends AbstractProcessor {
             source.append("package ").append(pkgName).append(";\n");
             source.append("public final class $JsCallbacks$ {\n");
             source.append("  static final $JsCallbacks$ VM = new $JsCallbacks$(null);\n");
-            source.append("  private final org.netbeans.html.boot.spi.Fn.Presenter p;\n");
+            source.append("  private final java.lang.ref.Reference<org.netbeans.html.boot.spi.Fn.Presenter> ref;\n");
             source.append("  private $JsCallbacks$ next;\n");
             source.append("  private $JsCallbacks$(org.netbeans.html.boot.spi.Fn.Presenter p) {\n");
-            source.append("    this.p = p;\n");
+            source.append("    this.ref = new java.lang.ref.WeakReference<org.netbeans.html.boot.spi.Fn.Presenter>(p);\n");
             source.append("  }\n");
             source.append("  synchronized final $JsCallbacks$ current() {\n");
             source.append("    org.netbeans.html.boot.spi.Fn.Presenter now = org.netbeans.html.boot.spi.Fn.activePresenter();\n");
             source.append("    $JsCallbacks$ thiz = this;\n");
             source.append("    for (;;) {\n");
-            source.append("      if (now == thiz.p) return thiz;\n");
+            source.append("      if (now == thiz.ref.get()) return thiz;\n");
             source.append("      if (thiz.next == null) {\n");
             source.append("        return thiz.next = new $JsCallbacks$(now);\n");
             source.append("      }\n");
@@ -486,6 +486,7 @@ public final class JavaScriptProcesor extends AbstractProcessor {
             sep = ", ";
         }
         source.append(") throws Throwable {\n");
+        source.append("    org.netbeans.html.boot.spi.Fn.Presenter p = ref.get(); \n");
         source.append(convert);
         if (useTryResources()) {
             source.append("    try (java.io.Closeable a = org.netbeans.html.boot.spi.Fn.activate(p)) { \n");

--- a/boot/src/main/java/org/netbeans/html/boot/spi/FallbackIdentity.java
+++ b/boot/src/main/java/org/netbeans/html/boot/spi/FallbackIdentity.java
@@ -20,7 +20,7 @@ package org.netbeans.html.boot.spi;
 
 import java.lang.ref.WeakReference;
 
-final class FallbackIdentity extends WeakReference<Fn.Presenter> implements Fn.Identity {
+final class FallbackIdentity extends WeakReference<Fn.Presenter> implements Fn.Ref {
     private final int hashCode;
 
     FallbackIdentity(Fn.Presenter p) {
@@ -29,7 +29,7 @@ final class FallbackIdentity extends WeakReference<Fn.Presenter> implements Fn.I
     }
 
     @Override
-    public Fn.Identity id() {
+    public Fn.Ref reference() {
         return this;
     }
 

--- a/boot/src/main/java/org/netbeans/html/boot/spi/FallbackIdentity.java
+++ b/boot/src/main/java/org/netbeans/html/boot/spi/FallbackIdentity.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.html.boot.spi;
+
+import java.lang.ref.WeakReference;
+
+final class FallbackIdentity extends WeakReference<Fn.Presenter> implements Fn.Identity {
+    private final int hashCode;
+
+    FallbackIdentity(Fn.Presenter p) {
+        super(p);
+        this.hashCode = p.hashCode();
+    }
+
+    @Override
+    public Fn.Identity id() {
+        return this;
+    }
+
+    @Override
+    public Fn.Presenter presenter() {
+        return get();
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj instanceof FallbackIdentity) {
+            return ((FallbackIdentity) obj).presenter() == presenter();
+        }
+        return false;
+    }
+}

--- a/boot/src/main/java/org/netbeans/html/boot/spi/Fn.java
+++ b/boot/src/main/java/org/netbeans/html/boot/spi/Fn.java
@@ -169,9 +169,13 @@ public abstract class Fn {
      * 
      * @param p the presenter that should be active until closable is closed
      * @return the closable to close
+     * @throws NullPointerException if the {@code p} is {@code null}
      * @since 0.7
      */
     public static Closeable activate(Presenter p) {
+        if (p == null) {
+            throw new NullPointerException();
+        }
         return FnContext.activate(p);
     }
     

--- a/boot/src/test/java/org/netbeans/html/boot/impl/FnTest.java
+++ b/boot/src/test/java/org/netbeans/html/boot/impl/FnTest.java
@@ -124,6 +124,11 @@ public class FnTest extends JsClassLoaderBase {
         methodClass = loader.loadClass(JsMethods.class.getName());
         close.close();
     }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void nullProcessorNPE() {
+        Fn.activate(null);
+    }
     
     @Test public void flushingPresenter() throws IOException {
         class FP implements Fn.Presenter, Flushable {

--- a/boot/src/test/java/org/netbeans/html/boot/impl/JsClassLoaderBase.java
+++ b/boot/src/test/java/org/netbeans/html/boot/impl/JsClassLoaderBase.java
@@ -205,7 +205,7 @@ public class JsClassLoaderBase {
     @Test public void plusOrMul() throws Throwable {
         Method st = methodClass.getMethod("plusOrMul", int.class, int.class);
         assertNotNull(Fn.activePresenter(), "Is there a presenter?");
-        Closeable c = Fn.activate(null);
+        Closeable c = FnContext.activate(null);
         try {
             assertNull(Fn.activePresenter(), "No presenter now");
             assertEquals(st.invoke(null, 6, 7), 42, "Mul in Java");
@@ -214,7 +214,7 @@ public class JsClassLoaderBase {
         }
         assertNotNull(Fn.activePresenter(), "Is there a presenter again");
         assertEquals(st.invoke(null, 6, 7), 13, "Plus in JavaScript");
-        c = Fn.activate(null);
+        c = FnContext.activate(null);
         try {
             assertNull(Fn.activePresenter(), "No presenter again");
             assertEquals(st.invoke(null, 6, 7), 42, "Mul in Java");

--- a/boot/src/test/java/org/netbeans/html/boot/spi/FallbackIdentityTest.java
+++ b/boot/src/test/java/org/netbeans/html/boot/spi/FallbackIdentityTest.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.html.boot.spi;
+
+import java.io.Reader;
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+import java.net.URL;
+import org.netbeans.junit.NbTestCase;
+import static org.testng.Assert.*;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class FallbackIdentityTest {
+
+    public FallbackIdentityTest() {
+    }
+
+    @Test
+    public void testIdAndWeak() {
+        Fn.Presenter p = new Fn.Presenter() {
+            @Override
+            public Fn defineFn(String arg0, String... arg1) {
+                return null;
+            }
+
+            @Override
+            public void displayPage(URL arg0, Runnable arg1) {
+            }
+
+            @Override
+            public void loadScript(Reader arg0) throws Exception {
+            }
+        };
+
+        Fn.Identity id1 = Fn.id(p);
+        Fn.Identity id2 = Fn.id(p);
+
+        assertNotSame(id1, id2);
+        assertEquals(id1, id2);
+        assertEquals(id1.hashCode(), id2.hashCode());
+
+        Reference<Fn.Presenter> ref = new WeakReference<>(p);
+        p = null;
+        NbTestCase.assertGC("Presenter is held weakly", ref);
+    }
+
+    @Test
+    public void testPresenterCanProvideItsOwnIdentity() {
+        class IdPresenter implements Fn.Presenter, Fn.Identity {
+            @Override
+            public Fn defineFn(String code, String... names) {
+                return null;
+            }
+
+            @Override
+            public void displayPage(URL page, Runnable onPageLoad) {
+            }
+
+            @Override
+            public void loadScript(Reader code) throws Exception {
+            }
+
+            @Override
+            public Fn.Identity id() {
+                return this;
+            }
+
+            @Override
+            public Fn.Presenter presenter() {
+                return this;
+            }
+        }
+        IdPresenter p = new IdPresenter();
+
+        assertSame(p, Fn.id(p));
+    }
+}

--- a/boot/src/test/java/org/netbeans/html/boot/spi/FallbackIdentityTest.java
+++ b/boot/src/test/java/org/netbeans/html/boot/spi/FallbackIdentityTest.java
@@ -24,10 +24,6 @@ import java.lang.ref.WeakReference;
 import java.net.URL;
 import org.netbeans.junit.NbTestCase;
 import static org.testng.Assert.*;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class FallbackIdentityTest {
@@ -52,8 +48,8 @@ public class FallbackIdentityTest {
             }
         };
 
-        Fn.Identity id1 = Fn.id(p);
-        Fn.Identity id2 = Fn.id(p);
+        Fn.Ref<?> id1 = Fn.ref(p);
+        Fn.Ref<?> id2 = Fn.ref(p);
 
         assertNotSame(id1, id2);
         assertEquals(id1, id2);
@@ -66,7 +62,7 @@ public class FallbackIdentityTest {
 
     @Test
     public void testPresenterCanProvideItsOwnIdentity() {
-        class IdPresenter implements Fn.Presenter, Fn.Identity {
+        class IdPresenter implements Fn.Presenter, Fn.Ref {
             @Override
             public Fn defineFn(String code, String... names) {
                 return null;
@@ -81,7 +77,7 @@ public class FallbackIdentityTest {
             }
 
             @Override
-            public Fn.Identity id() {
+            public Fn.Ref reference() {
                 return this;
             }
 
@@ -92,6 +88,11 @@ public class FallbackIdentityTest {
         }
         IdPresenter p = new IdPresenter();
 
-        assertSame(p, Fn.id(p));
+        assertSame(p, Fn.ref(p));
+    }
+
+    @Test
+    public void nullYieldsNullReference() {
+        assertNull(Fn.ref(null));
     }
 }

--- a/ko4j/pom.xml
+++ b/ko4j/pom.xml
@@ -130,6 +130,12 @@
         <artifactId>javax.servlet-api</artifactId>
         <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.netbeans.api</groupId>
+      <artifactId>org-netbeans-modules-nbjunit</artifactId>
+      <version>${netbeans.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
     <description>Binds net.java.html.json APIs together with knockout.js</description>
 </project>

--- a/ko4j/src/main/java/org/netbeans/html/ko4j/CacheObjs.java
+++ b/ko4j/src/main/java/org/netbeans/html/ko4j/CacheObjs.java
@@ -19,24 +19,26 @@
 
 package org.netbeans.html.ko4j;
 
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
 import org.netbeans.html.boot.spi.Fn;
 
 final class CacheObjs {
     /* both @GuardedBy CacheObjs.class */
     private static CacheObjs[] list = new CacheObjs[16];
     private static int listAt = 0;
-    private final Fn.Presenter ref;
+    private final Reference<Fn.Presenter> ref;
 
     /* both @GuardedBy presenter single threaded access */
     private Object[] jsObjects;
     private int jsIndex;
 
     private CacheObjs(Fn.Presenter p) {
-        this.ref = p;
+        this.ref = new WeakReference<Fn.Presenter>(p);
     }
 
     Fn.Presenter get() {
-        return ref;
+        return ref.get();
     }
 
     static synchronized CacheObjs find(Fn.Presenter key) {

--- a/ko4j/src/main/java/org/netbeans/html/ko4j/CacheObjs.java
+++ b/ko4j/src/main/java/org/netbeans/html/ko4j/CacheObjs.java
@@ -25,14 +25,14 @@ final class CacheObjs {
     /* both @GuardedBy CacheObjs.class */
     private static final CacheObjs[] list = new CacheObjs[16];
     private static int listAt = 0;
-    private final Fn.Identity ref;
+    private final Fn.Ref<?> ref;
 
     /* both @GuardedBy presenter single threaded access */
     private Object[] jsObjects;
     private int jsIndex;
 
     private CacheObjs(Fn.Presenter p) {
-        this.ref = Fn.id(p);
+        this.ref = Fn.ref(p);
     }
 
     Fn.Presenter get() {

--- a/ko4j/src/main/java/org/netbeans/html/ko4j/CacheObjs.java
+++ b/ko4j/src/main/java/org/netbeans/html/ko4j/CacheObjs.java
@@ -19,26 +19,24 @@
 
 package org.netbeans.html.ko4j;
 
-import java.lang.ref.Reference;
-import java.lang.ref.WeakReference;
 import org.netbeans.html.boot.spi.Fn;
 
 final class CacheObjs {
     /* both @GuardedBy CacheObjs.class */
-    private static CacheObjs[] list = new CacheObjs[16];
+    private static final CacheObjs[] list = new CacheObjs[16];
     private static int listAt = 0;
-    private final Reference<Fn.Presenter> ref;
+    private final Fn.Identity ref;
 
     /* both @GuardedBy presenter single threaded access */
     private Object[] jsObjects;
     private int jsIndex;
 
     private CacheObjs(Fn.Presenter p) {
-        this.ref = new WeakReference<Fn.Presenter>(p);
+        this.ref = Fn.id(p);
     }
 
     Fn.Presenter get() {
-        return ref.get();
+        return ref.presenter();
     }
 
     static synchronized CacheObjs find(Fn.Presenter key) {

--- a/ko4j/src/main/java/org/netbeans/html/ko4j/Knockout.java
+++ b/ko4j/src/main/java/org/netbeans/html/ko4j/Knockout.java
@@ -21,8 +21,6 @@ package org.netbeans.html.ko4j;
 import java.io.Closeable;
 import java.io.IOException;
 import java.lang.ref.Reference;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.Executor;
 import net.java.html.js.JavaScriptBody;
 import net.java.html.js.JavaScriptResource;

--- a/ko4j/src/main/java/org/netbeans/html/ko4j/Knockout.java
+++ b/ko4j/src/main/java/org/netbeans/html/ko4j/Knockout.java
@@ -20,6 +20,7 @@ package org.netbeans.html.ko4j;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.lang.ref.Reference;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executor;
@@ -150,10 +151,22 @@ final class Knockout  {
         funcs[index].call(data, ev);
     }
 
+    private static Fn.Presenter getPresenter(Object obj) {
+        if (obj instanceof Fn.Presenter) {
+            return (Fn.Presenter) obj;
+        } else {
+            if (obj == null) {
+                return null;
+            } else {
+                return (Fn.Presenter) ((Reference<?>)obj).get();
+            }
+        }
+    }
+
     final void valueHasMutated(final String propertyName, Object oldValue, Object newValue) {
         Object[] all = MapObjs.toArray(objs);
         for (int i = 0; i < all.length; i += 2) {
-            Fn.Presenter p = (Fn.Presenter) all[i];
+            Fn.Presenter p = getPresenter(all[i]);
             final Object o = all[i + 1];
             if (p != Fn.activePresenter()) {
                 if (p instanceof Executor) {

--- a/ko4j/src/main/java/org/netbeans/html/ko4j/Knockout.java
+++ b/ko4j/src/main/java/org/netbeans/html/ko4j/Knockout.java
@@ -155,7 +155,7 @@ final class Knockout  {
             if (obj == null) {
                 return null;
             } else {
-                return ((Fn.Identity) obj).presenter();
+                return ((Fn.Ref) obj).presenter();
             }
         }
     }

--- a/ko4j/src/main/java/org/netbeans/html/ko4j/Knockout.java
+++ b/ko4j/src/main/java/org/netbeans/html/ko4j/Knockout.java
@@ -20,7 +20,6 @@ package org.netbeans.html.ko4j;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.lang.ref.Reference;
 import java.util.concurrent.Executor;
 import net.java.html.js.JavaScriptBody;
 import net.java.html.js.JavaScriptResource;
@@ -156,7 +155,7 @@ final class Knockout  {
             if (obj == null) {
                 return null;
             } else {
-                return (Fn.Presenter) ((Reference<?>)obj).get();
+                return ((Fn.Identity) obj).presenter();
             }
         }
     }

--- a/ko4j/src/main/java/org/netbeans/html/ko4j/MapObjs.java
+++ b/ko4j/src/main/java/org/netbeans/html/ko4j/MapObjs.java
@@ -33,8 +33,8 @@ final class MapObjs {
         reset();
     }
 
-    static void reset() {
-        setOnlyPresenter(null);
+    synchronized static void reset() {
+        onlyPresenter = null;
         usePresenter = true;
     }
 
@@ -74,7 +74,7 @@ final class MapObjs {
         return key == getOnlyPresenter() ? now : null;
     }
 
-    static Object[] remove(Object now, Fn.Presenter key) {
+    synchronized static Object[] remove(Object now, Fn.Presenter key) {
         if (now instanceof MapObjs) {
             return ((MapObjs)now).remove(key);
         }
@@ -85,7 +85,11 @@ final class MapObjs {
         if (now instanceof MapObjs) {
             return ((MapObjs) now).all.toArray();
         }
-        return new Object[] { getOnlyPresenter(), now };
+        final Fn.Presenter p = getOnlyPresenter();
+        if (p == null) {
+            return new Object[0];
+        }
+        return new Object[] { p, now };
     }
 
     private Object put(Fn.Presenter key, Object js) {
@@ -127,10 +131,11 @@ final class MapObjs {
     }
 
     private static Fn.Presenter getOnlyPresenter() {
-        return onlyPresenter.get();
+        final Fn.Presenter p = onlyPresenter == null ? null : onlyPresenter.get();
+        return p;
     }
 
-    private static void setOnlyPresenter(Fn.Presenter aOnlyPresenter) {
-        onlyPresenter = new WeakReference<Fn.Presenter>(aOnlyPresenter);
+    private static void setOnlyPresenter(Fn.Presenter p) {
+        onlyPresenter = new WeakReference<Fn.Presenter>(p);
     }
 }

--- a/ko4j/src/main/java/org/netbeans/html/ko4j/MapObjs.java
+++ b/ko4j/src/main/java/org/netbeans/html/ko4j/MapObjs.java
@@ -19,14 +19,12 @@
 
 package org.netbeans.html.ko4j;
 
-import java.lang.ref.Reference;
-import java.lang.ref.WeakReference;
 import java.util.List;
 import net.java.html.json.Models;
 import org.netbeans.html.boot.spi.Fn;
 
 final class MapObjs {
-    private static Reference<Fn.Presenter> onlyPresenter;
+    private static Fn.Identity onlyPresenter;
     private static boolean usePresenter;
 
     static {
@@ -40,8 +38,12 @@ final class MapObjs {
 
     private final List<Object> all;
 
-    private MapObjs(Object... arr) {
-        this.all = Models.asList(arr);
+    private MapObjs(Fn.Identity id1, Object js) {
+        this.all = Models.asList(id1, js);
+    }
+
+    private MapObjs(Fn.Identity id1, Object js1, Fn.Identity id2, Object js2) {
+        this.all = Models.asList(id1, js1, id2, js2);
     }
 
 
@@ -60,9 +62,9 @@ final class MapObjs {
                 }
             }
             if (now == null) {
-                return new MapObjs(new WeakReference<Fn.Presenter>(key), js);
+                return new MapObjs(Fn.id(key), js);
             } else {
-                return new MapObjs(onlyPresenter, now, new WeakReference<Fn.Presenter>(key), js);
+                return new MapObjs(onlyPresenter, now, Fn.id(key), js);
             }
         }
     }
@@ -99,15 +101,15 @@ final class MapObjs {
                 return this;
             }
         }
-        all.add(new WeakReference<Fn.Presenter>(key));
+        all.add(Fn.id(key));
         all.add(js);
         return this;
     }
 
     boolean isSameKey(int index, Fn.Presenter key) {
         Object at = all.get(index);
-        if (at instanceof Reference<?>) {
-            at = ((Reference<?>)at).get();
+        if (at instanceof Fn.Identity) {
+            at = ((Fn.Identity)at).presenter();
         }
         return at == key;
     }
@@ -131,11 +133,11 @@ final class MapObjs {
     }
 
     private static Fn.Presenter getOnlyPresenter() {
-        final Fn.Presenter p = onlyPresenter == null ? null : onlyPresenter.get();
+        final Fn.Presenter p = onlyPresenter == null ? null : onlyPresenter.presenter();
         return p;
     }
 
     private static void setOnlyPresenter(Fn.Presenter p) {
-        onlyPresenter = new WeakReference<Fn.Presenter>(p);
+        onlyPresenter = Fn.id(p);
     }
 }

--- a/ko4j/src/main/java/org/netbeans/html/ko4j/MapObjs.java
+++ b/ko4j/src/main/java/org/netbeans/html/ko4j/MapObjs.java
@@ -24,7 +24,7 @@ import net.java.html.json.Models;
 import org.netbeans.html.boot.spi.Fn;
 
 final class MapObjs {
-    private static Fn.Identity onlyPresenter;
+    private static Fn.Ref onlyPresenter;
     private static boolean usePresenter;
 
     static {
@@ -38,11 +38,11 @@ final class MapObjs {
 
     private final List<Object> all;
 
-    private MapObjs(Fn.Identity id1, Object js) {
+    private MapObjs(Fn.Ref id1, Object js) {
         this.all = Models.asList(id1, js);
     }
 
-    private MapObjs(Fn.Identity id1, Object js1, Fn.Identity id2, Object js2) {
+    private MapObjs(Fn.Ref id1, Object js1, Fn.Ref id2, Object js2) {
         this.all = Models.asList(id1, js1, id2, js2);
     }
 
@@ -62,9 +62,9 @@ final class MapObjs {
                 }
             }
             if (now == null) {
-                return new MapObjs(Fn.id(key), js);
+                return new MapObjs(Fn.ref(key), js);
             } else {
-                return new MapObjs(onlyPresenter, now, Fn.id(key), js);
+                return new MapObjs(onlyPresenter, now, Fn.ref(key), js);
             }
         }
     }
@@ -101,15 +101,15 @@ final class MapObjs {
                 return this;
             }
         }
-        all.add(Fn.id(key));
+        all.add(Fn.ref(key));
         all.add(js);
         return this;
     }
 
     boolean isSameKey(int index, Fn.Presenter key) {
         Object at = all.get(index);
-        if (at instanceof Fn.Identity) {
-            at = ((Fn.Identity)at).presenter();
+        if (at instanceof Fn.Ref) {
+            at = ((Fn.Ref)at).presenter();
         }
         return at == key;
     }
@@ -138,6 +138,6 @@ final class MapObjs {
     }
 
     private static void setOnlyPresenter(Fn.Presenter p) {
-        onlyPresenter = Fn.id(p);
+        onlyPresenter = Fn.ref(p);
     }
 }

--- a/ko4j/src/test/java/org/netbeans/html/ko4j/MapObjsTest.java
+++ b/ko4j/src/test/java/org/netbeans/html/ko4j/MapObjsTest.java
@@ -20,6 +20,7 @@ package org.netbeans.html.ko4j;
 
 import java.io.Reader;
 import java.net.URL;
+import java.util.Arrays;
 import org.netbeans.html.boot.spi.Fn;
 import static org.testng.Assert.*;
 import org.testng.annotations.BeforeMethod;
@@ -38,6 +39,12 @@ public class MapObjsTest {
         MapObjs.reset();
         p1 = new Pres();
         p2 = new Pres();
+    }
+
+    @Test
+    public void testToArrayNoPresenterYet() {
+        Object[] arr = MapObjs.toArray(null);
+        assertEquals(arr.length, 0, "Empty array: " + Arrays.toString(arr));
     }
 
     @Test

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -166,10 +166,12 @@ $ mvn -f client/pom.xml process-classes exec:exec
         <h3>New in version 1.6.1</h3>
         <p>
             One model instance can be used in two views
-            (<a target="_blank" href="https://github.com/apache/incubator-netbeans-html4j/pull/14">PR #14</a>).
+            (<a target="_blank" href="https://github.com/apache/netbeans-html4j/pull/14">PR #14</a>).
+            GC related behavior has been improved
+            (<a target="_blank" href="https://github.com/apache/netbeans-html4j/pull/19">PR #19</a>).
             Safe and {@link net.java.html.boot.script.Scripts sanitized builder} to
             create {@link javax.script.ScriptEngine}-based execution environment
-            (<a target="_blank" href="https://github.com/apache/incubator-netbeans-html4j/pull/15">PR #15</a>).
+            (<a target="_blank" href="https://github.com/apache/netbeans-html4j/pull/15">PR #15</a>).
         </p>
 
         <h3>New in version 1.6</h3>
@@ -180,10 +182,10 @@ $ mvn -f client/pom.xml process-classes exec:exec
             when necessary.
             {@link net.java.html.json.ComputedProperty Computed properties} can
             depend on other computed properties -
-            <a target="_blank" href="https://github.com/apache/incubator-netbeans-html4j/pull/3">PR #3</a>.
+            <a target="_blank" href="https://github.com/apache/netbeans-html4j/pull/3">PR #3</a>.
             {@link net.java.html.js.JavaScriptResource} annotation has been
             made repeatable -
-            <a target="_blank" href="https://github.com/apache/incubator-netbeans-html4j/pull/4">PR #4</a>.
+            <a target="_blank" href="https://github.com/apache/netbeans-html4j/pull/4">PR #4</a>.
             <code>@Model</code> annotation processor bugfix 
             <a target="_blank" href="https://issues.apache.org/jira/browse/NETBEANS-621">#621</a>.
         </p>
@@ -193,9 +195,9 @@ $ mvn -f client/pom.xml process-classes exec:exec
         <p>
             The project has been donated to <a target="_blank" href="http://apache.org">Apache Foundation</a>
             and the code is now hosted in the
-            <a target="_blank" href="http://github.com/apache/incubator-netbeans-html4j">incubator repository</a>
+            <a target="_blank" href="http://github.com/apache/netbeans-html4j">incubator repository</a>
             along other Apache incubating projects. Contribute to the project by forking its
-            <a target="_blank" href="http://github.com/apache/incubator-netbeans-html4j">GitHub repository</a>.
+            <a target="_blank" href="http://github.com/apache/netbeans-html4j">GitHub repository</a>.
         </p>
 
         <p>


### PR DESCRIPTION
Especially when embedding HTML/Java in NetBeans based application, it is essential to make sure that unused presenters (like dialogs) can be GCed.

This PR introduces `Fn.Ref` class that is designed to hold a weak reference to a presenter. Each present can implement it using own way.