### PR TITLE
Enumerate @Model annotations first to be able to guess their package

### DIFF
--- a/json/src/main/java/org/netbeans/html/json/impl/ModelProcessor.java
+++ b/json/src/main/java/org/netbeans/html/json/impl/ModelProcessor.java
@@ -94,7 +94,7 @@ import org.openide.util.lookup.ServiceProvider;
 public final class ModelProcessor extends AbstractProcessor {
     private static final Logger LOG = Logger.getLogger(ModelProcessor.class.getName());
     private final Map<Element,String> models = new WeakHashMap<Element,String>();
-    private final Map<String,String> packages = new WeakHashMap<String,String>();
+    private final Map<String,String> packages = new HashMap<String,String>();
     private final Map<Element,Prprt[]> verify = new WeakHashMap<Element,Prprt[]>();
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {

--- a/json/src/main/java/org/netbeans/html/json/impl/ModelProcessor.java
+++ b/json/src/main/java/org/netbeans/html/json/impl/ModelProcessor.java
@@ -1880,7 +1880,8 @@ public final class ModelProcessor extends AbstractProcessor {
             isEnum[0] = false;
             final String simpleName = e.getSimpleName().toString();
             String pkg = packages.get(simpleName);
-            return pkg == null ? simpleName : pkg + '.' + simpleName;
+            String referencingPkg = findPkgName(p.e);
+            return pkg == null || pkg.equals(referencingPkg) ? simpleName : pkg + '.' + simpleName;
         }
 
         TypeMirror enm = processingEnv.getElementUtils().getTypeElement("java.lang.Enum").asType();


### PR DESCRIPTION
Having mutually referencing `@Model` annotations in different packages is problematic. For example the https://gitlab.com/luete/foodcoops-dukescript-netbeans project at revision `967feea5477da` isn't buildable.

Enumerating all annotated elements first and recording their package name seems to fix the problem.