### PR TITLE
Compile on OpenJDK8. Use OpenJFX 11 APIs. Skip tests on OpenJDK8

### DIFF
--- a/boot-agent-test/pom.xml
+++ b/boot-agent-test/pom.xml
@@ -29,6 +29,9 @@
     <artifactId>boot-agent-test</artifactId>
     <packaging>jar</packaging>
     <name>Dynamic Boot Test</name>
+    <properties>
+        <skipTests>${skipJavaFXTests}</skipTests>
+    </properties>
     <build>
         <plugins>
             <plugin>

--- a/boot-fx/pom.xml
+++ b/boot-fx/pom.xml
@@ -35,6 +35,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <publicPackages>net.java.html.boot.fx</publicPackages>
+    <skipTests>${skipJavaFXTests}</skipTests>
   </properties>
   <build>
       <plugins>
@@ -90,7 +91,14 @@
       <scope>test</scope>
       <type>jar</type>
     </dependency>
+    <dependency>
+      <artifactId>webswing-app-toolkit</artifactId>
+      <groupId>org.webswing</groupId>
+      <version>20.1.3</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
-    <description>A presentation provider to show JavaFX WebView 
-when a Java/HTML based application is about to boot.</description>
+  <description>A presentation provider to show JavaFX WebView 
+    when a Java/HTML based application is about to boot.
+  </description>
 </project>

--- a/boot-fx/src/main/java/org/netbeans/html/boot/fx/AbstractFXPresenter.java
+++ b/boot-fx/src/main/java/org/netbeans/html/boot/fx/AbstractFXPresenter.java
@@ -233,7 +233,7 @@ Fn.KeepAlive, Fn.ToJavaScript, Fn.FromJavaScript, Executor, Cloneable, Fn.Ref<Ab
                 throw new IllegalStateException(ex);
             }
         }
-        return (JSObject) newPOJOImpl.call("fxBrwsrId", hash, id);
+        return (JSObject) newPOJOImpl.call("fxBrwsrId", new Object[] { hash, id });
     }
 
     final Object undefined() {
@@ -244,13 +244,13 @@ Fn.KeepAlive, Fn.ToJavaScript, Fn.FromJavaScript, Executor, Cloneable, Fn.Ref<Ab
     }
 
     private int getArrayLength(Object val) throws JSException {
-        int length = ((Number) arraySizeFn().call("array", val, null)).intValue();
+        int length = ((Number) arraySizeFn().call("array", new Object[] { val, null })).intValue();
         return length;
     }
 
     private Object[] toArray(int length, Object val) throws JSException {
         Object[] arr = new Object[length];
-        arraySizeFn().call("array", val, arr);
+        arraySizeFn().call("array", new Object[] { val, arr });
         checkArray(arr);
         return arr;
     }
@@ -565,7 +565,7 @@ Fn.KeepAlive, Fn.ToJavaScript, Fn.FromJavaScript, Executor, Cloneable, Fn.Ref<Ab
                     synchronized (this) {
                         this.hash = -1;
                         this.id = -1;
-                        obj.call("fxBrwsrId", this);
+                        obj.call("fxBrwsrId", new Object[] { this });
                         assert this.hash != -1;
                         assert this.id != -1;
                         resultHash = this.hash;

--- a/boot-fx/src/main/java/org/netbeans/html/boot/fx/FXConsole.java
+++ b/boot-fx/src/main/java/org/netbeans/html/boot/fx/FXConsole.java
@@ -51,7 +51,7 @@ public final class FXConsole {
     }
     
     private void registerImpl(JSObject eng, String attr, Level l) {
-        eng.call("call", null, attr, l, this);
+        eng.call("call", new Object[] { null, attr, l, this });
     }
     
     public void log(Level l, String msg) {

--- a/boot-script/pom.xml
+++ b/boot-script/pom.xml
@@ -54,7 +54,6 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>2.3.2</version>
             <configuration>
                <source>1.7</source>
                <target>1.7</target>

--- a/boot-truffle/pom.xml
+++ b/boot-truffle/pom.xml
@@ -56,7 +56,6 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>2.3.2</version>
             <configuration>
                <source>1.7</source>
                <target>1.7</target>

--- a/html4j-maven-plugin/pom.xml
+++ b/html4j-maven-plugin/pom.xml
@@ -74,7 +74,6 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>2.3.2</version>
             <configuration>
                <source>1.7</source>
                <target>1.7</target>

--- a/json-tck/pom.xml
+++ b/json-tck/pom.xml
@@ -58,7 +58,6 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>2.3.2</version>
             <configuration>
                <source>1.8</source>
                <target>1.8</target>

--- a/ko-felix-test/pom.xml
+++ b/ko-felix-test/pom.xml
@@ -32,6 +32,7 @@
     <description>Runs the TCK for Knockout in Felix OSGi Container</description>
     <properties>
         <netbeans.compile.on.save>none</netbeans.compile.on.save>
+        <skipTests>${skipJavaFXTests}</skipTests>
     </properties>
     <build>
         <plugins>

--- a/ko-osgi-test/pom.xml
+++ b/ko-osgi-test/pom.xml
@@ -32,6 +32,7 @@
     <description>Runs the TCK for Knockout in Equinox OSGi Container</description>
     <properties>
         <netbeans.compile.on.save>none</netbeans.compile.on.save>
+        <skipTests>${skipJavaFXTests}</skipTests>
     </properties>
     <build>
         <plugins>

--- a/ko-ws-tyrus/pom.xml
+++ b/ko-ws-tyrus/pom.xml
@@ -52,9 +52,10 @@
         </plugins>
     </build>
     <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <bundleSymbolicName>org.netbeans.html.ko-ws-tyrus</bundleSymbolicName>
-  </properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <bundleSymbolicName>org.netbeans.html.ko-ws-tyrus</bundleSymbolicName>
+        <skipTests>${skipJavaFXTests}</skipTests>
+    </properties>
   <dependencies>
     <!-- compile only deps -->
     <dependency>

--- a/ko4j/pom.xml
+++ b/ko4j/pom.xml
@@ -36,6 +36,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <bundleSymbolicName>org.netbeans.html.ko4j</bundleSymbolicName>
     <netbeans.compile.on.save>none</netbeans.compile.on.save> 
+    <skipTests>${skipJavaFXTests}</skipTests>
   </properties>
   <build>
       <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,6 @@
   </parent>
   <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <javac.source>1.6</javac.source>
       <netbeans.version>RELEASE110</netbeans.version>
       <grizzly.version>2.3.8</grizzly.version>
       <license>COPYING</license>
@@ -43,6 +42,7 @@
       <javadoc.allowjs>--allow-script-in-comments</javadoc.allowjs>
       <sigtestPackages>${publicPackages}</sigtestPackages>
       <publicMetaInf>META-INF.services.*</publicMetaInf>
+      <skipJavaFXTests>true</skipJavaFXTests>
   </properties>
   <modules>
     <module>json</module>
@@ -154,7 +154,7 @@ org.netbeans.html.boot.impl:org.netbeans.html.boot.fx:org.netbeans.html.context.
                     <version>0.54</version>
                 </docletArtifact>
                 <additionalOptions>
-                    -snippetpath boot-fx/src/test 
+                    -snippetpath boot-fx/src/test
                     -snippetpath boot-script/src/test
                     -snippetpath json/src/test
                     -snippetpath webkit/src/test
@@ -275,10 +275,18 @@ org.netbeans.html.boot.impl:org.netbeans.html.boot.fx:org.netbeans.html.context.
               <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>3.8.1</version>
+                <dependencies>
+                    <dependency>
+                        <artifactId>compiler-maven-plugin</artifactId>
+                        <groupId>org.frgaal</groupId>
+                        <version>14.0.1</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
-                    <source>${javac.source}</source>
-                    <target>${javac.source}</target>
+                    <compilerId>frgaal</compilerId>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <testSource>1.8</testSource>
                     <testTarget>1.8</testTarget>
                 </configuration>
@@ -326,6 +334,36 @@ org.netbeans.html.boot.impl:org.netbeans.html.boot.fx:org.netbeans.html.context.
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.netbeans.tools</groupId>
+                <artifactId>sigtest-maven-plugin</artifactId>
+                <version>1.2</version>
+                <executions>
+                    <execution>
+                        <id>check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <phase>integration-test</phase>
+                        <configuration>
+                            <packages>${sigtestPackages}</packages>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <packages>${publicPackages}</packages>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <releaseVersion>1.7</releaseVersion>
+                </configuration>
             </plugin>
           </plugins>
       </pluginManagement>
@@ -508,61 +546,16 @@ org.netbeans.html.boot.impl:org.netbeans.html.boot.fx:org.netbeans.html.context.
               </file>
           </activation>
           <properties>
-            <jfxrt.jar>${java.home}/lib/ext/jfxrt.jar</jfxrt.jar>
-          </properties>
-          <build>
-              <plugins>
-                  <plugin>
-                      <groupId>org.netbeans.tools</groupId>
-                      <artifactId>sigtest-maven-plugin</artifactId>
-                      <version>1.2</version>
-                      <executions>
-                          <execution>
-                              <id>check</id>
-                              <goals>
-                                  <goal>check</goal>
-                              </goals>
-                              <phase>integration-test</phase>
-                              <configuration>
-                                  <packages>${sigtestPackages}</packages>
-                              </configuration>
-                          </execution>
-                          <execution>
-                              <id>generate</id>
-                              <goals>
-                                  <goal>generate</goal>
-                              </goals>
-                              <phase>package</phase>
-                              <configuration>
-                                  <packages>${publicPackages}</packages>
-                              </configuration>
-                          </execution>
-                      </executions>
-                      <configuration>
-                          <releaseVersion>1.7</releaseVersion>
-                      </configuration>
-                  </plugin>
-              </plugins>
-          </build>
-      </profile>
-      <profile>
-          <id>jdk7</id>
-          <activation>
-              <file>
-                  <exists>${java.home}/lib/jfxrt.jar</exists>
-              </file>
-          </activation>
-          <properties>
-            <jfxrt.jar>${java.home}/lib/jfxrt.jar</jfxrt.jar>
+              <skipJavaFXTests>false</skipJavaFXTests>
           </properties>
       </profile>
       <profile>
-          <id>jdk13+</id>
+          <id>jdk11+</id>
           <activation>
-              <jdk>[13,]</jdk>
+              <jdk>[11,]</jdk>
           </activation>
           <properties>
-              <javac.source>1.7</javac.source>
+              <skipJavaFXTests>false</skipJavaFXTests>
           </properties>
       </profile>
   </profiles>

--- a/sound/pom.xml
+++ b/sound/pom.xml
@@ -35,6 +35,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <publicPackages>net.java.html.sound</publicPackages>
+        <skipTests>${skipJavaFXTests}</skipTests>
     </properties>
     <build>
         <plugins>

--- a/xhr4j/pom.xml
+++ b/xhr4j/pom.xml
@@ -52,9 +52,10 @@
         </plugins>
     </build>
     <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <bundleSymbolicName>org.netbeans.html.xhr4j</bundleSymbolicName>
-  </properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <bundleSymbolicName>org.netbeans.html.xhr4j</bundleSymbolicName>
+        <skipTests>${skipJavaFXTests}</skipTests>
+    </properties>
   <dependencies>
     <!-- compile only deps -->
     <dependency>


### PR DESCRIPTION
Updating the project to be able to compile on JDK8 by using OpenJFX 11 APIs. Tests are skipped on OpenJDK8 however. Tests are executed on JDK8 with JavaFX and any JDK11+.