### PR TITLE
Annotation processors in Gradle do not see resources

### DIFF
--- a/html4j-maven-plugin/pom.xml
+++ b/html4j-maven-plugin/pom.xml
@@ -144,12 +144,13 @@
                   <plugin>
                       <groupId>org.thingsboard</groupId>
                       <artifactId>gradle-maven-plugin</artifactId>
-                      <version>1.0.9</version>
+                      <version>1.0.10</version>
                       <configuration>
                           <tasks>
                               <task>build</task>
                           </tasks>
                           <gradleProjectDirectory>src/test/resources/org/netbeans/html/mojo/gradle1</gradleProjectDirectory>
+                          <gradleVersion>6.3</gradleVersion>
                       </configuration>
                       <executions>
                           <execution>

--- a/html4j-maven-plugin/src/test/java/org/netbeans/html/mojo/Gradle1Test.java
+++ b/html4j-maven-plugin/src/test/java/org/netbeans/html/mojo/Gradle1Test.java
@@ -23,6 +23,7 @@ import java.io.Closeable;
 import java.io.Reader;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Properties;
 import java.util.concurrent.Callable;
 import org.netbeans.html.boot.spi.Fn;
 import static org.testng.Assert.*;
@@ -57,6 +58,7 @@ public class Gradle1Test {
     }
 
     private static final class NumberPresenter implements Fn.Presenter {
+        private final Properties p = new Properties();
 
         private int loadScriptCount;
 
@@ -66,7 +68,11 @@ public class Gradle1Test {
                 code = code.substring(6);
             }
             code = code.replace(';', ' ').trim();
-            return new NumberFn(Integer.valueOf(code));
+            String number = p.getProperty(code);
+            if (number == null) {
+                return new NumberFn(42);
+            }
+            return new NumberFn(Integer.valueOf(number));
         }
 
         @Override
@@ -76,6 +82,7 @@ public class Gradle1Test {
 
         @Override
         public void loadScript(Reader reader) throws Exception {
+            p.load(reader);
             loadScriptCount++;
         }
 

--- a/html4j-maven-plugin/src/test/resources/org/netbeans/html/mojo/gradle1/build.gradle
+++ b/html4j-maven-plugin/src/test/resources/org/netbeans/html/mojo/gradle1/build.gradle
@@ -36,11 +36,14 @@ version '1.0-SNAPSHOT'
 apply plugin: 'java'
 apply plugin: 'html4j'
 
-compileJava {
-    classpath += files("src/main/resources")
-}
+//compileJava {
+//    classpath += files("src/main/resources")
+//}
+
+def jars = fileTree(dir: '../../../../../../../../../boot/target/', include: ['*.jar'])
 
 dependencies {
-    compile fileTree(dir: '../../../../../../../../../boot/target/', include: ['*.jar'])
+    compile jars
+    annotationProcessor jars
 }
 

--- a/html4j-maven-plugin/src/test/resources/org/netbeans/html/mojo/gradle1/src/main/java/Gradle1Check.java
+++ b/html4j-maven-plugin/src/test/resources/org/netbeans/html/mojo/gradle1/src/main/java/Gradle1Check.java
@@ -21,7 +21,7 @@ import net.java.html.js.JavaScriptBody;
 import java.util.concurrent.Callable;
 import net.java.html.js.JavaScriptResource;
 
-@JavaScriptResource("/empty.js")
+@JavaScriptResource("/meaning.js")
 public class Gradle1Check implements Callable<Integer> {
 
     @Override
@@ -29,7 +29,7 @@ public class Gradle1Check implements Callable<Integer> {
         return compute();
     }
 
-    @JavaScriptBody(args = {}, body = "return 42;")
+    @JavaScriptBody(args = {}, body = "return meaningOfWorld;")
     private static int compute() {
         return -1;
     }

--- a/html4j-maven-plugin/src/test/resources/org/netbeans/html/mojo/gradle1/src/main/resources/meaning.js
+++ b/html4j-maven-plugin/src/test/resources/org/netbeans/html/mojo/gradle1/src/main/resources/meaning.js
@@ -16,3 +16,5 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
+meaningOfWorld = 42;


### PR DESCRIPTION
Turning the error into a warning. 

While working on the [react4jdemo](https://github.com/jtulach/netbeans-html4j/tree/react4jdemo) I had to face a problem of Gradle not putting resources on sourcepath of `javac` annotation processors. One way is to include those resources explicitly:
```
compileJava {
    classpath += files("src/main/resources")
}
```
but that one isn't really easy to find (I was searching for that trick for few days). Rather than that let's give up and surrender the Gradle dictate and turn the error into a warning. If the resource is really missing, it is going to yield a runtime error anyway.

Suggestions, Laszló?