### PR TITLE
Modelprocessor fix

### DIFF
--- a/json/src/test/java/net/java/html/json/sub/TelephoneCntrl.java
+++ b/json/src/test/java/net/java/html/json/sub/TelephoneCntrl.java
@@ -16,27 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package net.java.html.json;
+package net.java.html.json.sub;
 
-import static org.testng.Assert.assertNotNull;
-import org.testng.annotations.Test;
-import net.java.html.json.sub.Street;
-import net.java.html.json.sub.Telephone;
-@Model(className = "Address", properties = {
-    @Property(name = "street", type = net.java.html.json.sub.Street.class)
-})
-public class AdressTest {
-    @Test
-    public void addressHoldsAPerson() {
-        Address address = new Address();
-        assertNotNull(address.getStreet(), "Street is initialized");
-    }
+import net.java.html.json.Model;
+
+@Model(className = "Telephone", properties = {})
+public class TelephoneCntrl {
     
-    @ComputedProperty
-    public static String lowerCaseStreetName(Street street){
-        return street.getName().toLowerCase();
-    }
-    
-    @OnReceive(url = "")
-    public static void getTelephone(Address model, Telephone phone){}
 }


### PR DESCRIPTION
ModelProcessor does not resolve the FQN of Model Type Properties in @ComputedProperty and @OnReceive if they are in a different package. Instead it uses a wrong FQN and the compilation fails. Added a test and a fix. The fix generates imports in the import section of the class instead of using FQNs everywhere, which I think also improves readability.