### PR TITLE
Proper variable declaration in TCK

### DIFF
--- a/json-tck/src/main/resources/net/java/html/js/tests/initArray.js
+++ b/json-tck/src/main/resources/net/java/html/js/tests/initArray.js
@@ -16,5 +16,5 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-testArray = [];
+var testArray = [];
 


### PR DESCRIPTION
Making the test script compatible with strict mode.

The variable was assigned without declaration in order to force a global variable declaration, but JavaScript resources are executed in global scope anyway.