### PR TITLE
Code completions for callbacks from JavaScript to Java

### DIFF
--- a/boot/src/main/java/org/netbeans/html/boot/impl/JavaScriptProcesor.java
+++ b/boot/src/main/java/org/netbeans/html/boot/impl/JavaScriptProcesor.java
@@ -241,7 +241,7 @@ public final class JavaScriptProcesor extends AbstractProcessor {
         if (e.getKind() == ElementKind.METHOD && member.getSimpleName().contentEquals("body")) { // NOI18N
             return bodyCompletion(e, userText);
         }
-        return null;
+        return Collections.emptyList();
     }
 
     private Iterable<? extends Completion> argsCompletion(Element e) {
@@ -357,7 +357,7 @@ public final class JavaScriptProcesor extends AbstractProcessor {
                 }
             }
         }
-        return null;
+        return Collections.emptyList();
     }
 
     final void wrongArrayError(TypeMirror paramType, Element method) {

--- a/boot/src/main/java/org/netbeans/html/boot/impl/JavaScriptProcesor.java
+++ b/boot/src/main/java/org/netbeans/html/boot/impl/JavaScriptProcesor.java
@@ -23,6 +23,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Writer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -234,24 +235,148 @@ public final class JavaScriptProcesor extends AbstractProcessor {
     public Iterable<? extends Completion> getCompletions(Element e,
         AnnotationMirror annotation, ExecutableElement member, String userText
     ) {
+        if (e.getKind() == ElementKind.METHOD && member.getSimpleName().contentEquals("args")) { // NOI18N
+            return argsCompletion(e);
+        }
+        if (e.getKind() == ElementKind.METHOD && member.getSimpleName().contentEquals("body")) { // NOI18N
+            return bodyCompletion(e, userText);
+        }
+        return null;
+    }
+
+    private Iterable<? extends Completion> argsCompletion(Element e) {
         StringBuilder sb = new StringBuilder();
-        if (e.getKind() == ElementKind.METHOD && member.getSimpleName().contentEquals("args")) {
-            ExecutableElement ee = (ExecutableElement) e;
-            String sep = "";
-            sb.append("{ ");
-            for (VariableElement ve : ee.getParameters()) {
-                sb.append(sep).append('"').append(ve.getSimpleName())
+        ExecutableElement ee = (ExecutableElement) e;
+        String sep = "";
+        sb.append("{ ");
+        for (VariableElement ve : ee.getParameters()) {
+            sb.append(sep).append('"').append(ve.getSimpleName())
                     .append('"');
-                sep = ", ";
+            sep = ", ";
+        }
+        sb.append(" }");
+        return Collections.nCopies(1, Completions.of(sb.toString()));
+    }
+
+    private Iterable<? extends Completion> bodyCompletion(Element e, String userText) {
+        ExecutableElement ee = (ExecutableElement) e;
+        String identifier = endsWithIdentifier(userText);
+        int preIdentifierAt = userText.length() - identifier.length() - 1;
+        if (preIdentifierAt >= 0) {
+            char preId = userText.charAt(preIdentifierAt);
+            if (preId == '.' || preId == '@') {
+                int lastAt = userText.lastIndexOf('@', preIdentifierAt + 1);
+                String maybePackageName = preIdentifierAt > lastAt ? userText.substring(lastAt + 1, preIdentifierAt) : "";
+                if (!maybePackageName.isEmpty()) {
+                    PackageElement maybePackage = processingEnv.getElementUtils().getPackageElement(maybePackageName);
+                    if (maybePackage != null) {
+                        List<Completion> offer = new ArrayList<>();
+                        for (Element ch : maybePackage.getEnclosedElements()) {
+                            final String elemName = ch.getSimpleName().toString();
+                            if (elemName.startsWith(identifier)) {
+                                final String userCompl = userText.substring(0, lastAt + 1) + maybePackageName + "." + elemName + "::"; // NOI18N
+                                offer.add(Completions.of(userCompl));
+                            }
+                        }
+                        return offer;
+                    }
+                } else {
+                    String instanceName = null;
+                    if (lastAt > 0 && userText.charAt(lastAt - 1) == '.') {
+                        instanceName = endsWithIdentifier(userText, lastAt - 1);
+                        if (instanceName.isEmpty()) {
+                            instanceName = null;
+                        }
+                    }
+                    if (instanceName != null) {
+                        for (VariableElement p : ee.getParameters()) {
+                            if (p.getSimpleName().contentEquals(instanceName)) {
+                                Element et = processingEnv.getTypeUtils().asElement(p.asType());
+                                if (et.getKind().isClass() || et.getKind().isInterface()) {
+                                    String fqn = processingEnv.getElementUtils().getBinaryName((TypeElement) et).toString();
+                                    String type = userText.substring(0, lastAt + 1) + fqn + "::";
+                                    return Collections.nCopies(1, Completions.of(type));
+                                }
+                            }
+                        }
+                    }
+                }
+            } else if (preId == ':') {
+                int lastAt = userText.lastIndexOf('@', preIdentifierAt + 1);
+                String maybeClassName = userText.substring(lastAt + 1, preIdentifierAt - 1);
+                TypeElement maybeClass = processingEnv.getElementUtils().getTypeElement(maybeClassName);
+                String instanceName = null;
+                if (lastAt > 0 && userText.charAt(lastAt - 1) == '.') {
+                    instanceName = endsWithIdentifier(userText, lastAt - 1);
+                    if (instanceName.isEmpty()) {
+                        instanceName = null;
+                    }
+                }
+                if (maybeClass != null) {
+                    List<Completion> offer = new ArrayList<>();
+                    for (Element ch : maybeClass.getEnclosedElements()) {
+                        if (ch.getKind() != ElementKind.METHOD) {
+                            continue;
+                        }
+                        final String elemName = ch.getSimpleName().toString();
+                        if (elemName.startsWith(identifier)) {
+                            ExecutableElement m = (ExecutableElement) ch;
+                            boolean isStatic = m.getModifiers().contains(Modifier.STATIC);
+                            if (instanceName != null) {
+                                if (isStatic) {
+                                    continue;
+                                }
+                            } else {
+                                if (!isStatic) {
+                                    continue;
+                                }
+                            }
+
+                            StringBuilder invokeMethod = new StringBuilder().
+                                    append(userText.substring(0, lastAt + 1)).
+                                    append(maybeClassName).
+                                    append("::").
+                                    append(elemName).
+                                    append(findParamTypes(m)).
+                                    append("(");
+                            String sep = "";
+                            for (VariableElement p : m.getParameters()) {
+                                invokeMethod.append(sep);
+                                if (p.asType().getKind().isPrimitive()) {
+                                    invokeMethod.append("0");
+                                } else {
+                                    invokeMethod.append("null");
+                                }
+                                sep = ", ";
+                            }
+                            invokeMethod.append(")");
+                            offer.add(Completions.of(invokeMethod.toString()));
+                        }
+                    }
+                    return offer;
+                }
             }
-            sb.append(" }");
-            return Collections.nCopies(1, Completions.of(sb.toString()));
         }
         return null;
     }
 
     final void wrongArrayError(TypeMirror paramType, Element method) {
         processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Don't use " + paramType + " array. Use Object[].", method);
+    }
+
+    private static String endsWithIdentifier(String text) {
+        return endsWithIdentifier(text, text.length());
+    }
+
+    private static String endsWithIdentifier(String text, int max) {
+        int at = max;
+        while (--at >= 0) {
+            char ch = text.charAt(at);
+            if (!Character.isJavaIdentifierPart(ch)) {
+                break;
+            }
+        }
+        return text.substring(at + 1, max);
     }
 
     private class VerifyCallback extends JsCallback {
@@ -306,50 +431,6 @@ public final class JavaScriptProcesor extends AbstractProcessor {
                 mangledOnes.put(mangled, found);
             }
             return "";
-        }
-
-        private String findParamTypes(ExecutableElement method) {
-            ExecutableType t = (ExecutableType) method.asType();
-            StringBuilder sb = new StringBuilder();
-            sb.append('(');
-            for (TypeMirror paramType : t.getParameterTypes()) {
-                TypeMirror tm = paramType;
-                boolean isArray = false;
-                while (tm.getKind() == TypeKind.ARRAY) {
-                    sb.append('[');
-                    tm = ((ArrayType) tm).getComponentType();
-                    isArray = true;
-                }
-                if (tm.getKind().isPrimitive()) {
-                    switch (tm.getKind()) {
-                        case INT: sb.append('I'); break;
-                        case BOOLEAN: sb.append('Z'); break;
-                        case BYTE: sb.append('B'); break;
-                        case CHAR: sb.append('C'); break;
-                        case SHORT: sb.append('S'); break;
-                        case DOUBLE: sb.append('D'); break;
-                        case FLOAT: sb.append('F'); break;
-                        case LONG: sb.append('J'); break;
-                        default:
-                            throw new IllegalStateException("Unknown " + tm.getKind());
-                    }
-                    if (isArray) {
-                        wrongArrayError(paramType, method);
-                    }
-                } else {
-                    sb.append('L');
-                    Types tu = processingEnv.getTypeUtils();
-                    final TypeMirror erasedType = tu.erasure(tm);
-                    TypeMirror objectType = processingEnv.getElementUtils().getTypeElement("java.lang.Object").asType();
-                    if (isArray && !processingEnv.getTypeUtils().isSameType(objectType, erasedType)) {
-                        wrongArrayError(paramType, method);
-                    }
-                    Element elm = tu.asElement(erasedType);
-                    dumpElems(sb, elm, ';');
-                }
-            }
-            sb.append(')');
-            return sb.toString();
         }
     }
 
@@ -581,6 +662,50 @@ public final class JavaScriptProcesor extends AbstractProcessor {
             e = e.getEnclosingElement();
         }
         return ((PackageElement)e).getQualifiedName().toString();
+    }
+
+    private String findParamTypes(ExecutableElement method) {
+        ExecutableType t = (ExecutableType) method.asType();
+        StringBuilder sb = new StringBuilder();
+        sb.append('(');
+        for (TypeMirror paramType : t.getParameterTypes()) {
+            TypeMirror tm = paramType;
+            boolean isArray = false;
+            while (tm.getKind() == TypeKind.ARRAY) {
+                sb.append('[');
+                tm = ((ArrayType) tm).getComponentType();
+                isArray = true;
+            }
+            if (tm.getKind().isPrimitive()) {
+                switch (tm.getKind()) {
+                    case INT: sb.append('I'); break;
+                    case BOOLEAN: sb.append('Z'); break;
+                    case BYTE: sb.append('B'); break;
+                    case CHAR: sb.append('C'); break;
+                    case SHORT: sb.append('S'); break;
+                    case DOUBLE: sb.append('D'); break;
+                    case FLOAT: sb.append('F'); break;
+                    case LONG: sb.append('J'); break;
+                    default:
+                        throw new IllegalStateException("Unknown " + tm.getKind());
+                }
+                if (isArray) {
+                    wrongArrayError(paramType, method);
+                }
+            } else {
+                sb.append('L');
+                Types tu = processingEnv.getTypeUtils();
+                final TypeMirror erasedType = tu.erasure(tm);
+                TypeMirror objectType = processingEnv.getElementUtils().getTypeElement("java.lang.Object").asType();
+                if (isArray && !processingEnv.getTypeUtils().isSameType(objectType, erasedType)) {
+                    wrongArrayError(paramType, method);
+                }
+                Element elm = tu.asElement(erasedType);
+                dumpElems(sb, elm, ';');
+            }
+        }
+        sb.append(')');
+        return sb.toString();
     }
 
 }

--- a/boot/src/test/java/org/netbeans/html/boot/impl/Arithm.java
+++ b/boot/src/test/java/org/netbeans/html/boot/impl/Arithm.java
@@ -23,6 +23,9 @@ package org.netbeans.html.boot.impl;
  * @author Jaroslav Tulach
  */
 public class Arithm {
+    private Arithm() {
+    }
+
     public int sumTwo(int a, int b) {
         return a + b;
     }
@@ -33,5 +36,9 @@ public class Arithm {
             copy[i] = ((Number)arr[i]).intValue();
         }
         return 0;
+    }
+
+    public static Arithm create() {
+        return new Arithm();
     }
 }

--- a/boot/src/test/java/org/netbeans/html/boot/impl/Compile.java
+++ b/boot/src/test/java/org/netbeans/html/boot/impl/Compile.java
@@ -53,8 +53,7 @@ import static org.testng.Assert.fail;
  * @author Jaroslav Tulach
  */
 final class Compile implements DiagnosticListener<JavaFileObject> {
-    private final List<Diagnostic<? extends JavaFileObject>> errors = 
-            new ArrayList<Diagnostic<? extends JavaFileObject>>();
+    private final List<Diagnostic<? extends JavaFileObject>> errors = new ArrayList<>();
     private final Map<String, byte[]> classes;
     private final String pkg;
     private final String cls;
@@ -89,8 +88,7 @@ final class Compile implements DiagnosticListener<JavaFileObject> {
         return getDiagnostics(Diagnostic.Kind.ERROR);
     }
     public List<Diagnostic<? extends JavaFileObject>> getDiagnostics(Diagnostic.Kind kind) {
-        List<Diagnostic<? extends JavaFileObject>> err;
-        err = new ArrayList<Diagnostic<? extends JavaFileObject>>();
+        List<Diagnostic<? extends JavaFileObject>> err = new ArrayList<>();
         for (Diagnostic<? extends JavaFileObject> diagnostic : errors) {
             if (diagnostic.getKind() == kind) {
                 err.add(diagnostic);
@@ -102,8 +100,7 @@ final class Compile implements DiagnosticListener<JavaFileObject> {
     private Map<String, byte[]> compile(final String html, final String code) throws IOException {
         StandardJavaFileManager sjfm = ToolProvider.getSystemJavaCompiler().getStandardFileManager(this, null, null);
 
-        final Map<String, ByteArrayOutputStream> class2BAOS;
-        class2BAOS = new HashMap<String, ByteArrayOutputStream>();
+        final Map<String, ByteArrayOutputStream> class2BAOS = new HashMap<>();
 
         JavaFileObject file = new SimpleJavaFileObject(URI.create("mem://mem"), Kind.SOURCE) {
             @Override
@@ -122,13 +119,6 @@ final class Compile implements DiagnosticListener<JavaFileObject> {
                 return new ByteArrayInputStream(html.getBytes());
             }
         };
-        
-        final URI scratch;
-        try {
-            scratch = new URI("mem://mem3");
-        } catch (URISyntaxException ex) {
-            throw new IOException(ex);
-        }
         
         JavaFileManager jfm = new ForwardingJavaFileManager<JavaFileManager>(sjfm) {
             @Override
@@ -222,7 +212,7 @@ final class Compile implements DiagnosticListener<JavaFileObject> {
 
         ToolProvider.getSystemJavaCompiler().getTask(null, jfm, this, /*XXX:*/Arrays.asList("-source", sourceLevel, "-target", "1.7"), null, Arrays.asList(file)).call();
 
-        Map<String, byte[]> result = new HashMap<String, byte[]>();
+        Map<String, byte[]> result = new HashMap<>();
 
         for (Map.Entry<String, ByteArrayOutputStream> e : class2BAOS.entrySet()) {
             result.put(e.getKey(), e.getValue().toByteArray());

--- a/boot/src/test/java/org/netbeans/html/boot/impl/JavaScriptCompletionTest.java
+++ b/boot/src/test/java/org/netbeans/html/boot/impl/JavaScriptCompletionTest.java
@@ -1,0 +1,157 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.html.boot.impl;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.processing.Completion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import net.java.html.js.JavaScriptBody;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+import org.testng.annotations.Test;
+
+/**
+ *
+ * @author Jaroslav Tulach
+ */
+public class JavaScriptCompletionTest {
+
+    @Test
+    public void computeRunnableArgument() throws IOException {
+        String code = """
+            package x.y.z;
+            import net.java.html.js.JavaScriptBody;
+            class X {
+              @JavaScriptBody(args={}, body="")
+              private static native void callback(Runnable r);
+            }
+            """;
+        List<Completion> completions = new ArrayList<>();
+        Compile c = complete(completions, code, JavaScriptBody.class, "args", "");
+        c.assertNoErrors();
+        assertEquals(completions.size(), 1, "one suggestion found: " + completions);
+        assertEquals(completions.get(0).getValue(), "{ \"r\" }");
+    }
+
+    @Test
+    public void computeMultipleArguments() throws IOException {
+        String code = """
+            package x.y.z;
+            import net.java.html.js.JavaScriptBody;
+            class X {
+              @JavaScriptBody(args={}, body="")
+              private static native void substring(String s, int from, int length);
+            }
+            """;
+        List<Completion> completions = new ArrayList<>();
+        Compile c = complete(completions, code, JavaScriptBody.class, "args", "");
+        c.assertNoErrors();
+        assertEquals(completions.size(), 1, "one suggestion found: " + completions);
+        assertEquals(completions.get(0).getValue(), "{ \"s\", \"from\", \"length\" }");
+    }
+
+    @Test
+    public void completeCallToInstanceVariable() throws IOException {
+        String code = """
+            package x.y.z;
+            import net.java.html.js.JavaScriptBody;
+            import org.netbeans.html.boot.impl.Arithm;
+            class X {
+              @JavaScriptBody(args={}, body="")
+              private static native void arithm(Arithm a, int from, int length);
+            }
+            """;
+        List<Completion> completions = new ArrayList<>();
+        complete(completions, code, JavaScriptBody.class, "body", "a.@").assertNoErrors();
+        assertEquals(completions.size(), 1, "one suggestion found: " + completions);
+        assertEquals(completions.get(0).getValue(), "a.@org.netbeans.html.boot.impl.Arithm::", "Type of instance variable found");
+
+        complete(completions, code, JavaScriptBody.class, "body", "a.@org.netbeans.html.boot.impl.Arithm::").assertNoErrors();
+        assertEquals(completions.size(), 2, "two suggestions found: " + completions);
+        assertEquals(completions.get(0).getValue(), "a.@org.netbeans.html.boot.impl.Arithm::sumArr([Ljava/lang/Object;)(null)");
+        assertEquals(completions.get(1).getValue(), "a.@org.netbeans.html.boot.impl.Arithm::sumTwo(II)(0, 0)");
+    }
+
+    @Test
+    public void completeCallToStaticMethod() throws IOException {
+        String code = """
+            package x.y.z;
+            import net.java.html.js.JavaScriptBody;
+            import org.netbeans.html.boot.impl.Arithm;
+            class X {
+              @JavaScriptBody(args={}, body="")
+              private static native void code();
+            }
+            """;
+        List<Completion> completions = new ArrayList<>();
+        complete(completions, code, JavaScriptBody.class, "body", "var c = @org.netbeans.html.boot.impl.Arithm::").assertNoErrors();
+        assertEquals(completions.size(), 1, "one suggestion found: " + completions);
+        assertEquals(completions.get(0).getValue(), "var c = @org.netbeans.html.boot.impl.Arithm::create()()");
+
+        complete(completions, code, JavaScriptBody.class, "body", "var c = @org.netbeans.html.boot.impl.").assertNoErrors();
+        assertNotEquals(completions.size(), 0, "some suggestions found: " + completions);
+        OK: {
+            for (Completion item : completions) {
+                if (item.getValue().equals("var c = @org.netbeans.html.boot.impl.Arithm::")) {
+                    break OK;
+                }
+            }
+            fail("Should find class Arithm in the package: " + completions);
+        }
+    }
+
+    private static Compile complete(List<Completion> completions, String code, Class<?> annotatedBy, String attribute, String userText) throws IOException {
+        completions.clear();
+        MockProcessor.registerConsumer(annotatedBy, (env, round) -> {
+            JavaScriptProcesor jsp = new JavaScriptProcesor();
+            jsp.init(env);
+
+            for (Element e : round.getElementsAnnotatedWith(JavaScriptBody.class)) {
+                if (e.getKind() != ElementKind.METHOD) {
+                    continue;
+                }
+                ExecutableElement method = (ExecutableElement) e;
+                for (AnnotationMirror a : method.getAnnotationMirrors() ) {
+                    for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> value : a.getElementValues().entrySet()) {
+                        final ExecutableElement execElem = value.getKey();
+                        if (execElem.getSimpleName().contentEquals(attribute)) {
+                            assertTrue(completions.isEmpty(), "Already filled with something: " + completions);
+                            for (Completion item : jsp.getCompletions(e, a, execElem, userText)) {
+                                completions.add(item);
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        Compile c = Compile.create("", code);
+        Collections.sort(completions, (a, b) -> a.getValue().compareTo(b.getValue()));
+        return c;
+    }
+}

--- a/boot/src/test/java/org/netbeans/html/boot/impl/JsMethods.java
+++ b/boot/src/test/java/org/netbeans/html/boot/impl/JsMethods.java
@@ -69,7 +69,7 @@ public class JsMethods {
     private static native int sumTwo(Arithm at, int... arr);
 
     public static int sumArr(int... arr) {
-        return sumTwo(new Arithm(), arr);
+        return sumTwo(Arithm.create(), arr);
     }
 
     @JavaScriptBody(args = {"r"}, javacall = true, body =
@@ -82,7 +82,7 @@ public class JsMethods {
     private static native int sumArr(Arithm r);
 
     public static int sumArr() {
-        return sumArr(new Arithm());
+        return sumArr(Arithm.create());
     }
 
     @JavaScriptBody(args = { "x", "y" }, body = "return mul(x, y);")

--- a/boot/src/test/java/org/netbeans/html/boot/impl/MockProcessor.java
+++ b/boot/src/test/java/org/netbeans/html/boot/impl/MockProcessor.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.html.boot.impl;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+import org.openide.util.lookup.ServiceProvider;
+
+@ServiceProvider(service = Processor.class)
+public final class MockProcessor extends AbstractProcessor {
+    private static final LinkedHashMap<BiConsumer<ProcessingEnvironment,RoundEnvironment>,Class<?>> PENDING = new LinkedHashMap<>();
+
+    static void registerConsumer(Class<?> annotation, BiConsumer<ProcessingEnvironment,RoundEnvironment> consumer) {
+        synchronized (PENDING) {
+            PENDING.put(consumer, annotation);
+        }
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        for (;;) {
+            BiConsumer<ProcessingEnvironment, RoundEnvironment> c;
+            synchronized (PENDING) {
+                if (PENDING.isEmpty()) {
+                    return true;
+                }
+                Iterator<Map.Entry<BiConsumer<ProcessingEnvironment, RoundEnvironment>, Class<?>>> it = PENDING.entrySet().iterator();
+                c = it.next().getKey();
+                it.remove();
+            }
+            c.accept(processingEnv, roundEnv);
+        }
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latest();
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        LinkedHashSet<String> types = new LinkedHashSet<>();
+        synchronized (PENDING) {
+            for (Class<?> c : PENDING.values()) {
+                types.add(c.getName());
+            }
+        }
+        return types;
+    }
+}

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -163,6 +163,12 @@ $ mvn -f client/pom.xml process-classes exec:exec
             vm.loadClass('org.apidesign.demo.minesweeper.MainBrwsr');
         </script>
         
+        <h3>New in version 1.7.2</h3>
+        <p>
+            Code completions for callbacks from JavaScript to Java -
+            <a target="_blank" href="https://github.com/apache/netbeans-html4j/pull/36">PR #36</a>.
+        </p>
+
         <h3>New in version 1.7.1</h3>
         <p>
             Bugfix release to address robustness and security issues.


### PR DESCRIPTION
Support for `@JavaScriptBody` annotation completions. The callback syntax is described at [net.java.html.js package](https://bits.netbeans.org/html+java/1.7.1/net/java/html/js/package-summary.html). A `body` attribute can contain `@fqn::method(paramTypes)(values)` static callbacks and `arg.@fqn::method(paramTypes)(values)` instance callback. The code completion should work on `x.@|`, `@java.lang.|` locations to completeclass names and then also method names.

The code complation seems to work in NetBeans IDE. I haven't got it working in VSCode yet.

![obrazek](https://user-images.githubusercontent.com/26887752/121070397-f7d42d00-c7ce-11eb-90fa-bec9a521e508.png)
![obrazek](https://user-images.githubusercontent.com/26887752/121070489-133f3800-c7cf-11eb-81fc-c6960970dbf6.png)

Try the completion on [Bodies.java](https://github.com/apache/netbeans-html4j/blob/master/json-tck/src/main/java/net/java/html/js/tests/Bodies.java) for example.