### PR TITLE
Using three different subclasses of frames

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
       dist: trusty
       jdk: openjdk8
       env:
-        - ARGS=-Dcom.dukescript.presenters.browser=firefox
+        - ARGS=-Dnone
         - DIR=zulu8.40.0.25-ca-fx-jdk8.0.222-linux_x64
         - URL=https://cdn.azul.com/zulu/bin/$DIR.tar.gz
     - os: linux
@@ -58,7 +58,7 @@ matrix:
       dist: trusty
       jdk: openjdk15
       env:
-        - ARGS=-Dcom.dukescript.presenters.browser=firefox
+        - ARGS=-Dnone
         - JAVADOC=yes
     - os: osx
       name: Mac JDK8

--- a/browser/src/test/java/org/netbeans/html/presenters/browser/DumpStack.java
+++ b/browser/src/test/java/org/netbeans/html/presenters/browser/DumpStack.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.html.presenters.browser;
+
+import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
+
+final class DumpStack extends TimerTask {
+
+    private static final Timer TIMER = new Timer("Dump Stack Watchdog");
+    private final long created = System.currentTimeMillis();
+
+    @Override
+    public void run() {
+        StringBuilder sb = new StringBuilder();
+        long after = (System.currentTimeMillis() - created) / 1000;
+        sb.append("Thread dump after ").append(after).append(" s from start:\n");
+        for (Map.Entry<Thread, StackTraceElement[]> info : Thread.getAllStackTraces().entrySet()) {
+            sb.append(info.getKey().getName()).append("\n");
+            for (StackTraceElement e : info.getValue()) {
+                sb.append("    ").append(e.getClassName()).append(".").
+                        append(e.getMethodName()).append("(").append(e.getFileName()).
+                        append(":").append(e.getLineNumber()).append(")\n");
+            }
+        }
+        System.err.println(sb.toString());
+    }
+
+    public static void initialize() {
+        final int minute = 60000;
+        TIMER.schedule(new DumpStack(), minute, 2 * minute);
+    }
+}

--- a/browser/src/test/java/org/netbeans/html/presenters/browser/ServerFactories.java
+++ b/browser/src/test/java/org/netbeans/html/presenters/browser/ServerFactories.java
@@ -35,6 +35,10 @@ public final class ServerFactories {
     private ServerFactories() {
     }
 
+    static {
+        DumpStack.initialize();
+    }
+
     @DataProvider(name = "serverFactories")
     public static Object[][] serverFactories() {
         Supplier<HttpServer<?,?,?,?>> grizzly = GrizzlyServer::new;

--- a/generic/src/test/java/org/netbeans/html/presenters/spi/test/DumpStack.java
+++ b/generic/src/test/java/org/netbeans/html/presenters/spi/test/DumpStack.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.html.presenters.spi.test;
+
+import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
+
+final class DumpStack extends TimerTask {
+
+    private static final Timer TIMER = new Timer("Dump Stack Watchdog");
+    private final long created = System.currentTimeMillis();
+
+    @Override
+    public void run() {
+        StringBuilder sb = new StringBuilder();
+        long after = (System.currentTimeMillis() - created) / 1000;
+        sb.append("Thread dump after ").append(after).append(" s from start:\n");
+        for (Map.Entry<Thread, StackTraceElement[]> info : Thread.getAllStackTraces().entrySet()) {
+            sb.append(info.getKey().getName()).append("\n");
+            for (StackTraceElement e : info.getValue()) {
+                sb.append("    ").append(e.getClassName()).append(".").
+                        append(e.getMethodName()).append("(").append(e.getFileName()).
+                        append(":").append(e.getLineNumber()).append(")\n");
+            }
+        }
+        System.err.println(sb.toString());
+    }
+
+    public static void initialize() {
+        final int minute = 60000;
+        TIMER.schedule(new DumpStack(), minute, 2 * minute);
+    }
+}

--- a/generic/src/test/java/org/netbeans/html/presenters/spi/test/GenericTest.java
+++ b/generic/src/test/java/org/netbeans/html/presenters/spi/test/GenericTest.java
@@ -34,6 +34,10 @@ public class GenericTest {
     public GenericTest() {
     }
 
+    static {
+        DumpStack.initialize();
+    }
+
     @Factory public static Object[] compatibilityTests() throws Exception {
         return createTests(new Testing());
     }

--- a/json-tck/src/main/java/net/java/html/js/tests/AsyncJavaScriptAction.java
+++ b/json-tck/src/main/java/net/java/html/js/tests/AsyncJavaScriptAction.java
@@ -18,10 +18,15 @@
  */
 package net.java.html.js.tests;
 
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 import net.java.html.js.JavaScriptBody;
 import static net.java.html.js.tests.JavaScriptBodyTest.assertEquals;
+import static net.java.html.js.tests.JavaScriptBodyTest.assertTrue;
+import static net.java.html.js.tests.JavaScriptBodyTest.fail;
 
 final class AsyncJavaScriptAction {
     private List<Integer> collected = new java.util.ArrayList<>();
@@ -79,22 +84,30 @@ final class AsyncJavaScriptAction {
         }
         flushPendingJavaScripts();
         assertEquals(collected.size(), 11, "11 items: " + collected);
-        for (int i = 0; i < 11; i++) {
-            final Integer atI = collected.get(i);
-            final int iMinus5 = i - 5;
-            assertEquals(atI, iMinus5, i + "th out of order: " + collected);
-        }
+        assertSequenceButN(collected, -5, 6, 1);
         assertEquals(iteration.apply(11), 16);
         if (!successStoringLater) {
             return;
         }
         flushPendingJavaScripts();
-        assertEquals(collected.size(), 22, "22 items: " + collected);
-        for (int i = 0; i < 22; i++) {
-            final Integer atI = collected.get(i);
-            final int iMinus5 = i - 5;
-            assertEquals(atI, iMinus5, i + "th out of order: " + collected);
+        assertSequenceButN(collected, -5, 17, 2);
+    }
+
+    private static void assertSequenceButN(List<Integer> data, int from, int upto, int allowedDisorder) {
+        int count = upto - from;
+        assertEquals(data.size(), count, "all items: " + data);
+        Set<Integer> all = new HashSet<>(data);
+        Integer prev = null;
+        for (int i = from, at = 0; i < upto; i++, at++) {
+            final Integer atI = data.get(at);
+            if (prev != null && prev < atI) {
+                if (--allowedDisorder < 0) {
+                    fail("expecting ordered data from " + from + ".." + (upto - 1) + " but too many misorders: " + data);
+                }
+            }
+            all.remove(i);
         }
+        assertTrue(all.isEmpty(), from + ".." + (upto - 1) + " in " + data);
     }
 
     public void testWithCallback() {

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -169,6 +169,8 @@ $ mvn -f client/pom.xml process-classes exec:exec
             <a target="_blank" href="https://github.com/apache/netbeans-html4j/pull/36">PR #36</a>.
             Support for ecj -
             <a target="_blank" href="https://github.com/apache/netbeans-html4j/pull/37">PR #37</a>.
+            Robustness of {@link org.netbeans.html.presenters.spi.ProtoPresenter} improved -
+            <a target="_blank" href="https://github.com/apache/netbeans-html4j/pull/38">PR #38</a>.
         </p>
 
         <h3>New in version 1.7.1</h3>


### PR DESCRIPTION
Introducing three different subclasses of `Frame`:
* `CallJavaMethod` - that JavaScript uses to call a Java method
* `EvalJavaScript` - that Java uses to evaluate a JavaScript
* `DeferJavaScript` - that Java uses to evaluate a JavaScript _sometime later_

