### PR TITLE
No @JavaScriptBody on constructors.

### DIFF
--- a/boot/src/main/java/net/java/html/js/JavaScriptBody.java
+++ b/boot/src/main/java/net/java/html/js/JavaScriptBody.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
  * @author Jaroslav Tulach
  */
 @Retention(RetentionPolicy.CLASS)
-@Target({ ElementType.METHOD, ElementType.CONSTRUCTOR })
+@Target({ ElementType.METHOD })
 public @interface JavaScriptBody {
     /** Names of parameters for the method generated method that can
      * be referenced from {@link #body()}.


### PR DESCRIPTION
`@JavaScriptBody` has never been tested on constructors by the TCK. There are [reports](https://github.com/jtulach/bck2brwsr/issues/4) that it doesn't work. In fact (not being tested), it is unlikely to work on any platform.

Changing the TCK and requesting (many existing) implementations to implement it, is unlikely to succeed. Better to remove ability to apply the annotation on constructors all together.