### PR TITLE
Giving the presenter modules fully qualified names

### DIFF
--- a/browser/pom.xml
+++ b/browser/pom.xml
@@ -31,6 +31,7 @@
     <name>DukeScript Presenter for any Browser</name>
     <properties>
         <main.dir>${project.parent.basedir}</main.dir>
+        <bundleSymbolicName>org.netbeans.html.presenters.browser</bundleSymbolicName>
         <publicPackages>org.netbeans.html.presenters.browser</publicPackages>
         <sigtestPackages />
         <com.dukescript.presenters.browser>default</com.dukescript.presenters.browser>

--- a/generic/pom.xml
+++ b/generic/pom.xml
@@ -33,6 +33,7 @@
     <version>2.0-SNAPSHOT</version>
     <properties>
         <main.dir>${project.parent.basedir}</main.dir>
+        <bundleSymbolicName>org.netbeans.html.presenters.spi</bundleSymbolicName>
         <publicPackages>org.netbeans.html.presenters.spi</publicPackages>
         <publicMetaInf />
         <sigtestPackages />

--- a/ko-osgi-test/pom.xml
+++ b/ko-osgi-test/pom.xml
@@ -119,6 +119,36 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>generic</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>browser</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>webkit</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>net.java.html.geo</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>net.java.html.sound</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-web</artifactId>
             <scope>test</scope>

--- a/ko-osgi-test/src/main/java/org/netbeans/html/ko/osgi/test/KnockoutEquinoxTCKImpl.java
+++ b/ko-osgi-test/src/main/java/org/netbeans/html/ko/osgi/test/KnockoutEquinoxTCKImpl.java
@@ -72,9 +72,12 @@ public class KnockoutEquinoxTCKImpl extends KnockoutTCK implements Callable<Clas
     public Class[] call() throws Exception {
         return testClasses();
     }
-    
-    public static void start(URI server) throws Exception {
-        final BrowserBuilder bb = BrowserBuilder.newBrowser().loadClass(KnockoutEquinoxTCKImpl.class).
+
+    private static Object presenter;
+    public static void start(URI server, BundleContext ctx) throws Exception {
+        Class<?> clazz = loadOSGiClass("org.netbeans.html.boot.fx.FXPresenter", ctx);
+        presenter = clazz.newInstance();
+        final BrowserBuilder bb = BrowserBuilder.newBrowser(presenter).loadClass(KnockoutEquinoxTCKImpl.class).
             loadPage(server.toString()).
             invoke("initialized");
 
@@ -110,7 +113,7 @@ public class KnockoutEquinoxTCKImpl extends KnockoutTCK implements Callable<Clas
     @Override
     public BrwsrCtx createContext() {
         try {
-            Contexts.Builder cb = Contexts.newBuilder().
+            Contexts.Builder cb = Contexts.newBuilder(presenter).
                 register(Technology.class, (Technology)osgiInstance("KOTech"), 10).
                 register(Transfer.class, (Transfer)osgiInstance("KOTransfer"), 10).
                 register(Executor.class, (Executor)browserContext, 10);

--- a/pom.xml
+++ b/pom.xml
@@ -492,7 +492,7 @@ org.netbeans.html.boot.impl:org.netbeans.html.boot.fx:org.netbeans.html.context.
             <artifactId>org.apache.felix.framework</artifactId>
             <version>4.2.1</version>
         </dependency>
-      <dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>3.1.0</version>
@@ -533,6 +533,18 @@ org.netbeans.html.boot.impl:org.netbeans.html.boot.fx:org.netbeans.html.context.
             <groupId>org.netbeans.api</groupId>
             <type>jar</type>
             <version>${netbeans.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.dukescript.api</groupId>
+            <artifactId>junit-browser-runner</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.netbeans.html</groupId>
+                    <artifactId>net.java.html</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <artifactId>js</artifactId>

--- a/renderer/pom.xml
+++ b/renderer/pom.xml
@@ -31,6 +31,7 @@
     <name>Desktop Browser Renderer</name>
     <properties>
         <main.dir>${project.parent.basedir}</main.dir>
+        <bundleSymbolicName>org.netbeans.html.presenters.render</bundleSymbolicName>
         <publicPackages>org.netbeans.html.presenters.render</publicPackages>
         <publicMetaInf />
         <sigtestPackages />

--- a/sound/pom.xml
+++ b/sound/pom.xml
@@ -64,8 +64,12 @@
         <dependency>
             <groupId>com.dukescript.api</groupId>
             <artifactId>junit-browser-runner</artifactId>
-            <version>1.0</version>
-            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.netbeans.html</groupId>
+                    <artifactId>net.java.html</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.netbeans.html</groupId>

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -163,6 +163,16 @@ $ mvn -f client/pom.xml process-classes exec:exec
             vm.loadClass('org.apidesign.demo.minesweeper.MainBrwsr');
         </script>
         
+        <h3>New in version 1.7.3</h3>
+        <p>
+            Giving proper OSGi name to 
+            <code>org.netbeans.html.presenters.spi</code>,
+            <code>org.netbeans.html.presenters.render</code>,
+            <code>org.netbeans.html.presenters.browser</code> and
+            <code>org.netbeans.html.presenters.webkit</code> modules -
+            <a target="_blank" href="https://github.com/apache/netbeans-html4j/pull/40">PR #40</a>.
+        </p>
+        
         <h3>New in version 1.7.2</h3>
         <p>
             Code completions for callbacks from JavaScript to Java -

--- a/webkit/pom.xml
+++ b/webkit/pom.xml
@@ -32,6 +32,7 @@
     <properties>
         <netbeans.compile.on.save>none</netbeans.compile.on.save>
         <main.dir>${project.parent.basedir}</main.dir>
+        <bundleSymbolicName>org.netbeans.html.presenters.webkit</bundleSymbolicName>
         <publicPackages>org.netbeans.html.presenters.webkit</publicPackages>
         <sigtestPackages />
     </properties>


### PR DESCRIPTION
The [WebView experiment](https://github.com/JaroslavTulach/netbeans/commit/9028ce1c8b5007e5ad9381f7f92472bb90d8f3cc) requires additional HTML/Java modules. Alas, it turns out they are not properly named. This PR provides a test and rename of the modules to:
```
org.netbeans.html.presenters.spi
org.netbeans.html.presenters.render
org.netbeans.html.presenters.browser
org.netbeans.html.presenters.webkit
```

Technically this is an incompatible change, but given the poor OSGi name of the modules, I doubt anyone really tried to use them as OSGi bundles.