### PR TITLE
Convert values in arrays recursively when passing/returning from JS to Java

### DIFF
--- a/boot-script/src/main/java/net/java/html/boot/script/ScriptPresenter.java
+++ b/boot-script/src/main/java/net/java/html/boot/script/ScriptPresenter.java
@@ -194,6 +194,9 @@ Presenter, Fn.FromJavaScript, Fn.ToJavaScript, Executor {
         }
         Object[] arr = new Object[length];
         fn.invokeImpl(null, false, val, arr);
+        for (int i = 0; i < length; i++) {
+            arr[i] = toJava(arr[i]);
+        }
         return arr;
     }
 

--- a/boot/src/test/java/org/netbeans/html/boot/impl/JsUtils.java
+++ b/boot/src/test/java/org/netbeans/html/boot/impl/JsUtils.java
@@ -58,6 +58,9 @@ final class JsUtils {
             if (len != null && len.intValue() >= 0) {
                 java.lang.Object[] arr = new java.lang.Object[len.intValue()];
                 ((Invocable) eng).invokeFunction("checkArray", js, arr);
+                for (int i = 0; i < arr.length; i++) {
+                    arr[i] = toJava(eng, arr[i]);
+                }
                 return arr;
             }
             return js;

--- a/json-tck/src/main/java/net/java/html/js/tests/Bodies.java
+++ b/json-tck/src/main/java/net/java/html/js/tests/Bodies.java
@@ -276,4 +276,7 @@ final class Bodies {
         """
     )
     static native Object invoke(Object o, String n, Object arg);
+
+    @JavaScriptBody(args = {}, body = "return [['eggs']];")
+    static native Object createNested();
 }

--- a/json-tck/src/main/java/net/java/html/js/tests/JavaScriptBodyTest.java
+++ b/json-tck/src/main/java/net/java/html/js/tests/JavaScriptBodyTest.java
@@ -463,6 +463,15 @@ public class JavaScriptBodyTest {
         assertEquals(value[1], "NetBeans", "As read later by different method");
     }
 
+    @KOTest
+    public void nestedArray() {
+        Object nested = Bodies.createNested();
+        assertTrue(nested instanceof Object[], "Returns an array: " + nested);
+        Object flat = ((Object[]) nested)[0];
+        assertTrue(flat instanceof Object[], "Containing an array: " + flat);
+        assertEquals("eggs", ((Object[]) flat)[0]);
+    }
+
     private static class R implements Runnable {
         int cnt;
         private final Thread initThread;


### PR DESCRIPTION
- `json-tck`
  - add a test that returns a nested array from a `@JavaScriptBody` method
- `boot-script/.../ScriptPresenter.java`
  - call the `toJava` method recursively on each element
- `boot/.../JsUtils.java`
  - same as `ScriptPresenter`