### PR TITLE
Generic presenter shall be able to work only with asynchronous promises

### DIFF
--- a/generic/src/test/java/org/netbeans/html/presenters/spi/test/AsyncJavaOnlyTest.java
+++ b/generic/src/test/java/org/netbeans/html/presenters/spi/test/AsyncJavaOnlyTest.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.html.presenters.spi.test;
+
+import net.java.html.js.tests.AsyncJavaTest;
+import org.netbeans.html.json.tck.KOTest;
+import static org.netbeans.html.presenters.spi.test.GenericTest.createTests;
+import org.testng.annotations.Factory;
+
+public class AsyncJavaOnlyTest {
+    @Factory
+    public static Object[] compatibilityTests() throws Exception {
+        return createTests(new PromisesOnly(), (m) -> {
+            if (m.getDeclaringClass() == AsyncJavaTest.class) {
+                return m.getAnnotation(KOTest.class) != null;
+            }
+            return false;
+        });
+    }
+
+    private static final class PromisesOnly extends Testing {
+        @Override
+        protected String js2java(String method, Object a1, Object a2, Object a3, Object a4) throws Exception {
+            switch (method) {
+                case "p":
+                    // promise is OK
+                    break;
+                case "r":
+                    // result of JavaScript evaluation
+                    break;
+                default:
+                    throw new IllegalStateException("Unexpected method " + method + "(" + a1 + ", " + a2 + ", " + a3 + ", " + a4 + "). Expecting only promises!");
+            }
+            return super.js2java(method, a1, a2, a3, a4);
+        }
+    }
+}

--- a/generic/src/test/java/org/netbeans/html/presenters/spi/test/Testing.java
+++ b/generic/src/test/java/org/netbeans/html/presenters/spi/test/Testing.java
@@ -91,16 +91,20 @@ class Testing {
         return Level.FINE;
     }
 
+    private String ts(Object o) {
+        return o == null ? null : o.toString();
+    }
+
+    protected String js2java(String method, Object a1, Object a2, Object a3, Object a4) throws Exception {
+        return presenter.js2java(method, ts(a1), ts(a2), ts(a3), ts(a4));
+    }
+
     public final class Clbk {
         private Clbk() {
         }
 
-        private String ts(Object o) {
-            return o == null ? null : o.toString();
-        }
-
         public String pass(String method, Object a1, Object a2, Object a3, Object a4) throws Exception {
-            return presenter.js2java(method, ts(a1), ts(a2), ts(a3), ts(a4));
+            return js2java(method, ts(a1), ts(a2), ts(a3), ts(a4));
         }
     }
     private final Clbk clbk = new Clbk();

--- a/json-tck/src/main/java/net/java/html/js/tests/AsyncJavaScriptAction.java
+++ b/json-tck/src/main/java/net/java/html/js/tests/AsyncJavaScriptAction.java
@@ -26,9 +26,13 @@ final class AsyncJavaScriptAction {
     private AsyncJavaScriptAction() {
     }
 
-    static AsyncJavaScriptAction defineCallback() {
+    static AsyncJavaScriptAction defineCallback(boolean wait4js) {
         AsyncJavaScriptAction action = new AsyncJavaScriptAction();
-        action.defineCallbackImpl();
+        if (wait4js) {
+            action.defineCallbackImpl();
+        } else {
+            action.defineCallbackImplNoWait4js();
+        }
         return action;
     }
 
@@ -40,6 +44,15 @@ final class AsyncJavaScriptAction {
         };
     """)
     private native void defineCallbackImpl();
+
+    @JavaScriptBody(args = {}, javacall = true, wait4js = false, wait4java = false, body = """
+        var self = this;
+        var global = (0 || eval)("this");
+        global.callJava = function(s) {
+            self.@net.java.html.js.tests.AsyncJavaScriptAction::callJava(I)(s);
+        };
+    """)
+    private native void defineCallbackImplNoWait4js();
 
     void callJava(int i) {
         this.result = i;

--- a/json-tck/src/main/java/net/java/html/js/tests/AsyncJavaTest.java
+++ b/json-tck/src/main/java/net/java/html/js/tests/AsyncJavaTest.java
@@ -30,7 +30,11 @@ public class AsyncJavaTest {
         PhaseExecutor.schedule(phases, () -> {
             boolean[] javaExecuted = { false };
             Object objWithX = AsyncJava.computeInAsyncJava(5, (n) -> {
-                return new Factorial().factorial(n);
+                int acc = 1;
+                for (int i = 1; i <= n; i++) {
+                    acc *= i;
+                }
+                return acc;
             }, () -> {});
             int initialValue = Bodies.readIntX(objWithX);
             assertEquals(-1, initialValue, "Promise.then shall only be called when the code ends");
@@ -43,8 +47,17 @@ public class AsyncJavaTest {
 
     @KOTest
     public void initializedFromJavaScript() throws Exception {
+        initializedFromJavaScript(true);
+    }
+
+    @KOTest
+    public void initializedFromJavaScriptNoWait4js() throws Exception {
+        initializedFromJavaScript(false);
+    }
+
+    private void initializedFromJavaScript(boolean wait4js) throws Exception {
         PhaseExecutor.schedule(phases, () -> {
-            return AsyncJavaScriptAction.defineCallback();
+            return AsyncJavaScriptAction.defineCallback(wait4js);
         }).then((action) -> {
             AsyncJavaScriptAction.invokeCallbackLater(33);
         }).then((action) -> {


### PR DESCRIPTION
Ideally the `Generic` presenter shall receive only `p` requests when the call is consistently sending Java requests via `wait4java=false`. It doesn't in version 1.8 - `flushImpl` may send regular like request if there is a some `DefferedJavaScript` pending.

This PR writes a test that executes only `AsyncJavaTest` (or others that are known to be promises safe) and will reject every non `p` request.