### PR TITLE
Enable CI builds on JDK 21.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [ '8', '11', '17' ]
+        java: [ '8', '11', '17', '21' ]
         os: [ ubuntu-20.04 ]
 
     steps:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [ '8', '11', '17' ]
+        java: [ '8', '11', '17', '21' ]
         os: [ macos-10.15 ]
 
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [ '8', '11', '17' ]
+        java: [ '8', '11', '17', '21' ]
         os: [ windows-2019 ]
 
     steps:

--- a/boot/src/test/java/org/netbeans/html/boot/impl/Compile.java
+++ b/boot/src/test/java/org/netbeans/html/boot/impl/Compile.java
@@ -71,7 +71,7 @@ final class Compile implements DiagnosticListener<JavaFileObject> {
     /** Performs compilation of given HTML page and associated Java code
      */
     public static Compile create(String html, String code) throws IOException {
-        return create(html, code, "1.7");
+        return create(html, code, "8");
     }
     static Compile create(String html, String code, String sourceLevel) throws IOException {
         return new Compile(html, code, sourceLevel);
@@ -210,7 +210,7 @@ final class Compile implements DiagnosticListener<JavaFileObject> {
             }
         };
 
-        ToolProvider.getSystemJavaCompiler().getTask(null, jfm, this, /*XXX:*/Arrays.asList("-source", sourceLevel, "-target", "1.7"), null, Arrays.asList(file)).call();
+        ToolProvider.getSystemJavaCompiler().getTask(null, jfm, this, /*XXX:*/Arrays.asList("-source", sourceLevel, "-target", sourceLevel), null, Arrays.asList(file)).call();
 
         Map<String, byte[]> result = new HashMap<>();
 

--- a/geo/src/test/java/org/netbeans/html/geo/impl/Compile.java
+++ b/geo/src/test/java/org/netbeans/html/geo/impl/Compile.java
@@ -70,7 +70,7 @@ final class Compile implements DiagnosticListener<JavaFileObject> {
     /** Performs compilation of given HTML page and associated Java code
      */
     public static Compile create(String html, String code) throws IOException {
-        return create(html, code, "1.7");
+        return create(html, code, "8");
     }
     static Compile create(String html, String code, String sourceLevel) throws IOException {
         return new Compile(html, code, sourceLevel);
@@ -202,7 +202,7 @@ final class Compile implements DiagnosticListener<JavaFileObject> {
             }
         };
 
-        ToolProvider.getSystemJavaCompiler().getTask(null, jfm, this, /*XXX:*/Arrays.asList("-source", sourceLevel, "-target", "1.7"), null, Arrays.asList(file)).call();
+        ToolProvider.getSystemJavaCompiler().getTask(null, jfm, this, /*XXX:*/Arrays.asList("-source", sourceLevel, "-target", sourceLevel), null, Arrays.asList(file)).call();
 
         Map<String, byte[]> result = new HashMap<String, byte[]>();
 

--- a/json/src/test/java/net/java/html/json/Compile.java
+++ b/json/src/test/java/net/java/html/json/Compile.java
@@ -70,7 +70,7 @@ final class Compile implements DiagnosticListener<JavaFileObject> {
     /** Performs compilation of given HTML page and associated Java code
      */
     public static Compile create(String html, String code) throws IOException {
-        return create(html, code, "1.7");
+        return create(html, code, "8");
     }
     static Compile create(String html, String code, String sourceLevel) throws IOException {
         return new Compile(html, code, sourceLevel);
@@ -225,7 +225,7 @@ final class Compile implements DiagnosticListener<JavaFileObject> {
             }
         };
 
-        ToolProvider.getSystemJavaCompiler().getTask(null, jfm, this, /*XXX:*/Arrays.asList("-source", sourceLevel, "-target", "1.7"), null, Arrays.asList(file)).call();
+        ToolProvider.getSystemJavaCompiler().getTask(null, jfm, this, /*XXX:*/Arrays.asList("-source", sourceLevel, "-target", sourceLevel), null, Arrays.asList(file)).call();
 
         Map<String, byte[]> result = new HashMap<String, byte[]>();
 


### PR DESCRIPTION
Give up on `-source 1.7` in order to run on JDK 21 easily. Given the lowest JDK we test on is JDK 8, there is little point in sticking with `-source` and `-target` `1.7` in tests. Let's use `8` instead. The alternative would be to use [Frgaal](http://frgaal.org) and stick with older compiler even on newer JDKs, but that is probably not good either - we want to be sure we compile with JDK's own `javac`.