### PR TITLE
Make the CI Actions jobs Green

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -31,8 +31,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [ '16', '17' ]
-        os: [ ubuntu-20.04 ]
+        java: [ '17' ]
+        os: [ ubuntu-22.04 ]
 
     steps:
     - uses: actions/checkout@v2
@@ -41,7 +41,6 @@ jobs:
       with:
         distribution: 'zulu'
         java-version: ${{ matrix.java }}
-        cache: maven
 
     - name: Build
       run: mvn -q install -DskipTests

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         java: [ '8', '11', '17', '21' ]
-        os: [ ubuntu-20.04 ]
+        os: [ ubuntu-22.04 ]
 
     steps:
     - uses: actions/checkout@v2
@@ -41,7 +41,6 @@ jobs:
       with:
         distribution: 'zulu'
         java-version: ${{ matrix.java }}
-        cache: maven
 
     - name: Build with Maven
       run: mvn -q install -DskipTests

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [ '11', '17', '21' ]
+        java: [ '11', '17' ] 
         os: [ macos-14 ]
 
     steps:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -31,8 +31,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [ '8', '11', '17', '21' ]
-        os: [ macos-13 ]
+        java: [ '11', '17', '21' ]
+        os: [ macos-14 ]
 
     steps:
     - uses: actions/checkout@v2
@@ -41,7 +41,6 @@ jobs:
       with:
         distribution: 'zulu'
         java-version: ${{ matrix.java }}
-        cache: maven
 
     - name: Build with Maven
       run: mvn -q install -DskipTests

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         java: [ '8', '11', '17', '21' ]
-        os: [ windows-2019 ]
+        os: [ windows-2022 ]
 
     steps:
     - uses: actions/checkout@v2
@@ -41,7 +41,6 @@ jobs:
       with:
         distribution: 'zulu'
         java-version: ${{ matrix.java }}
-        cache: maven
 
     - name: Build with Maven
       run: mvn -q install -DskipTests

--- a/boot-fx/src/test/java/org/netbeans/html/boot/fx/KOFx.java
+++ b/boot-fx/src/test/java/org/netbeans/html/boot/fx/KOFx.java
@@ -22,8 +22,12 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javafx.application.Platform;
+import javafx.stage.Stage;
 import org.netbeans.html.boot.spi.Fn;
+import static org.testng.Assert.fail;
 import org.testng.IHookCallBack;
 import org.testng.IHookable;
 import org.testng.ITest;
@@ -36,7 +40,7 @@ import org.testng.annotations.Test;
  */
 public final class KOFx implements ITest, IHookable, Runnable {
     private static final Timer SCHEDULER = new Timer("Fx Scheduler");
-    
+
     private final Fn.Presenter p;
     private final Method m;
     private Object result;
@@ -99,7 +103,7 @@ public final class KOFx implements ITest, IHookable, Runnable {
     public void run(IHookCallBack ihcb, ITestResult itr) {
         ihcb.runTestMethod(itr);
     }
-    
+
     private static void schedule(Runnable task, long delay) {
         SCHEDULER.schedule(new TimerTask() {
             @Override
@@ -107,5 +111,19 @@ public final class KOFx implements ITest, IHookable, Runnable {
                 Platform.runLater(task);
             }
         }, delay);
+    }
+
+    static void assertTitle(Stage s, String expTitle, String msg) {
+        for (var i = 0; i < 100; i++) {
+            var title = s.getTitle();
+            if (expTitle.equals(title)) {
+                return;
+            }
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException ex) {
+            }
+        }
+        fail(msg + " expecting: " + expTitle + " but was: " + s.getTitle());
     }
 }

--- a/boot-fx/src/test/java/org/netbeans/html/boot/fx/PopupTest.java
+++ b/boot-fx/src/test/java/org/netbeans/html/boot/fx/PopupTest.java
@@ -26,6 +26,7 @@ import javafx.stage.Stage;
 import net.java.html.BrwsrCtx;
 import net.java.html.boot.BrowserBuilder;
 import net.java.html.js.JavaScriptBody;
+import static org.netbeans.html.boot.fx.KOFx.assertTitle;
 import org.netbeans.html.boot.spi.Fn;
 import static org.testng.Assert.*;
 import org.testng.annotations.Test;
@@ -84,23 +85,20 @@ public class PopupTest {
 
         assertNotNull(lastWebView[0], "A WebView created");
         Stage s = (Stage) lastWebView[0].getScene().getWindow();
-        assertEquals(s.getTitle(), "FX Presenter Harness");
+        assertTitle(s, "FX Presenter Harness", "Initial title value read from HTML page");
 
         final Object[] window = new Object[1];
         final CountDownLatch openWindow = new CountDownLatch(1);
-        when.ctx.execute(new Runnable() {
-            @Override
-            public void run() {
-                TitleTest.changeTitle("First window");
-                window[0] = openSecondaryWindow("second.html");
-                openWindow.countDown();
-            }
+        when.ctx.execute(() -> {
+            TitleTest.changeTitle("First window");
+            window[0] = openSecondaryWindow("second.html");
+            openWindow.countDown();
         });
 
         openWindow.await(5, TimeUnit.SECONDS);
 
         assertNotNull(window[0], "Second window opened");
 
-        assertEquals(s.getTitle(), "First window", "The title is kept");
+        assertTitle(s, "First window", "The title is kept");
     }
 }

--- a/boot-fx/src/test/java/org/netbeans/html/boot/fx/TitleTest.java
+++ b/boot-fx/src/test/java/org/netbeans/html/boot/fx/TitleTest.java
@@ -21,13 +21,13 @@ package org.netbeans.html.boot.fx;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
 import net.java.html.BrwsrCtx;
 import net.java.html.boot.BrowserBuilder;
 import net.java.html.js.JavaScriptBody;
+import static org.netbeans.html.boot.fx.KOFx.assertTitle;
 import org.netbeans.html.boot.spi.Fn;
 import static org.testng.Assert.*;
 import org.testng.annotations.Test;
@@ -88,25 +88,19 @@ public class TitleTest {
 
         assertNotNull(lastWebView[0], "A WebView created");
         Stage s = (Stage) lastWebView[0].getScene().getWindow();
-        assertEquals(s.getTitle(), "FX Presenter Harness");
+        assertTitle(s, "FX Presenter Harness", "Initial title is read from HTML page");
 
         final CountDownLatch propChange = new CountDownLatch(1);
-        s.titleProperty().addListener(new ChangeListener<String>() {
-            @Override
-            public void changed(ObservableValue<? extends String> ov, String t, String t1) {
-                propChange.countDown();
-            }
+        s.titleProperty().addListener((ObservableValue<? extends String> ov, String t, String t1) -> {
+            propChange.countDown();
         });
 
-        when.ctx.execute(new Runnable() {
-            @Override
-            public void run() {
-                changeTitle("New title");
-            }
+        when.ctx.execute(() -> {
+            changeTitle("New title");
         });
 
         propChange.await(5, TimeUnit.SECONDS);
-        assertEquals(s.getTitle(), "New title");
+        assertTitle(s, "New title", "Title is dynamically updated");
     }
 
     final void doCheckReload() throws Exception {

--- a/ecj-test/pom.xml
+++ b/ecj-test/pom.xml
@@ -51,6 +51,7 @@
           <plugin>
               <artifactId>maven-javadoc-plugin</artifactId>
               <configuration>
+                  <subpackages>org.netbeans.html.ecjtest.dummy</subpackages>
                   <skip>true</skip>
               </configuration>
           </plugin>

--- a/ecj-test/src/main/java/org/netbeans/html/ecjtest/dummy/Dummy.java
+++ b/ecj-test/src/main/java/org/netbeans/html/ecjtest/dummy/Dummy.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */package org.netbeans.html.ecjtest.dummy;
+
+/** Dummy class.
+ */
+public final class Dummy {
+    private Dummy() {
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
       <netbeans.version>RELEASE130</netbeans.version>
       <graalvm.version>21.3.0</graalvm.version>
       <grizzly.version>2.3.8</grizzly.version>
+      <openjfx.version>11.0.2</openjfx.version>
       <license>COPYING</license>
       <publicPackages />
       <bundleSymbolicName>${project.artifactId}</bundleSymbolicName>
@@ -393,13 +394,13 @@ org.netbeans.html.boot.impl:org.netbeans.html.boot.fx:org.netbeans.html.context.
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-web</artifactId>
-            <version>11</version>
+            <version>${openjfx.version}</version>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-swing</artifactId>
             <scope>test</scope>
-            <version>11</version>
+            <version>${openjfx.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin.external.google</groupId>


### PR DESCRIPTION
- currently the CI jobs are broken because they hasn't been maintained for a long time
- a lot of base images has been deprecated meanwhile
- updating to pass the tests somehow