### PR TITLE
Supporting browser builtin implementation of `AudioClip` again

### DIFF
--- a/sound/src/main/java/org/netbeans/html/sound/impl/BrowserAudioEnv.java
+++ b/sound/src/main/java/org/netbeans/html/sound/impl/BrowserAudioEnv.java
@@ -33,9 +33,13 @@ public final class BrowserAudioEnv implements AudioEnvironment<Object> {
     }
     
     @Override
-    @JavaScriptBody(args = { "src" }, body = ""
-        + "if (typeof Audio !== 'object') return null;"
-        + "return new Audio(src);")
+    @JavaScriptBody(args = { "src" }, body = """
+    if (typeof Audio === 'undefined') {
+        return null;
+    } else {
+        return new Audio(src);
+    }
+    """)
     public Object create(String src) {
         // null if not running in browser
         return null;

--- a/sound/src/test/java/net/java/html/sound/AudioClipTest.java
+++ b/sound/src/test/java/net/java/html/sound/AudioClipTest.java
@@ -42,7 +42,8 @@ public class AudioClipTest {
     public void testAudioSystemIsSupported() {
         var clip = AudioClip.create("non-existing.mp3");
         if (assumeAudioObject()) {
-            assertTrue("Playing should be supported on modern browsers", clip.isSupported());
+            var p = Fn.activePresenter().getClass().getName();
+            assertTrue("Playing should be supported on " + p, clip.isSupported());
         }
     }
 
@@ -62,7 +63,6 @@ public class AudioClipTest {
         var errMsg = createAudioObjectOrFail();
         var p = Fn.activePresenter().getClass().getName();
         if (errMsg == null) {
-            System.err.println("Audio found for " + p);
             return true;
         } else {
             // it is expected that ScriptPresenter doesn't have Audio

--- a/sound/src/test/java/net/java/html/sound/AudioClipTest.java
+++ b/sound/src/test/java/net/java/html/sound/AudioClipTest.java
@@ -18,9 +18,13 @@
  */
 package net.java.html.sound;
 
+import net.java.html.js.JavaScriptBody;
 import net.java.html.junit.BrowserRunner;
+import static org.junit.Assert.assertTrue;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.netbeans.html.boot.spi.Fn;
 
 @RunWith(BrowserRunner.class)
 public class AudioClipTest {
@@ -30,6 +34,40 @@ public class AudioClipTest {
 
     @Test
     public void testPlayNonExistingClip() {
-        AudioClip.create("non-existing.mp3").play();
+        var clip = AudioClip.create("non-existing.mp3");
+        clip.play();
+    }
+
+    @Test
+    public void testAudioSystemIsSupported() {
+        var clip = AudioClip.create("non-existing.mp3");
+        if (assumeAudioObject()) {
+            assertTrue("Playing should be supported on modern browsers", clip.isSupported());
+        }
+    }
+
+    @JavaScriptBody(args = {  }, body = """
+    try {
+        var audio = new Audio("any.mp3");
+        return null;
+    } catch (err) {
+        return "Error constructing new Audio: " + err.toString();
+    }
+    """)
+    private static String createAudioObjectOrFail() {
+        return "Not running in a browser at all!";
+    }
+
+    private static boolean assumeAudioObject() {
+        var errMsg = createAudioObjectOrFail();
+        var p = Fn.activePresenter().getClass().getName();
+        if (errMsg == null) {
+            System.err.println("Audio found for " + p);
+            return true;
+        } else {
+            // it is expected that ScriptPresenter doesn't have Audio
+            Assume.assumeTrue("No Audio for " + p + ":" + errMsg, p.contains("ScriptPresenter"));
+            return false;
+        }
     }
 }

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -163,6 +163,11 @@ $ mvn -f client/pom.xml process-classes exec:exec
             vm.loadClass('org.apidesign.demo.minesweeper.MainBrwsr');
         </script>
 
+        <h3>New in version 1.8.3</h3>
+        <p>
+            {@link net.java.html.sound.AudioClip} plays music again via internal browser audio system - see
+            <a target="_blank" href="https://github.com/apache/netbeans-html4j/pull/56">PR #56</a> for details.
+        </p>
         <h3>New in version 1.8.2</h3>
         <p>
             When post-processing classes with <code>-javaagent</code> instrumenting agent


### PR DESCRIPTION
- while working on https://github.com/jtulach/minesweeper/pull/3 & co.
- I realized HTML/Java Sound API can no longer play via browser's `Audio` object
- writing a test that [initially fails](https://github.com/apache/netbeans-html4j/actions/runs/25903977489/job/76133352693?pr=56#step:5:473)
- providing a fix in b2c602d8723fa072245d71bc6b30640a23a0b966